### PR TITLE
Add single-destructure rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  config: ['standard']
+}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ npm install --save-dev eslint-plugin-ember-standard
 *   [import](documentation/rules/import.md)
 *   [logger](documentation/rules/logger.md)
 *   [no-set-in-computed-property](documentation/rules/no-set-in-computed-property.md)
+*   [single-destructure](documentation/rules/single-destructure.md)
 
 [bithound-img]: https://www.bithound.io/github/ciena-blueplanet/eslint-plugin-ember-standard/badges/score.svg "bitHound"
 [bithound-url]: https://www.bithound.io/github/ciena-blueplanet/eslint-plugin-ember-standard

--- a/documentation/rules/single-destructure.md
+++ b/documentation/rules/single-destructure.md
@@ -1,0 +1,28 @@
+# single-destructure
+
+This rule ensures Ember is destructured in a single variable declarator.
+
+**ESLint Configuration**
+
+```json
+{
+  "rules": {
+    "ember-standard/single-destructure": 2
+  }
+}
+```
+
+**Valid**
+
+```js
+import Ember from 'ember'
+const {Component, Logger} = Ember
+```
+
+**Invalid**
+
+```js
+import Ember from 'ember'
+const {Component} = Ember
+const {Logger} = Ember
+```

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ module.exports = {
         'ember-standard/destructure': [2, "always"],
         'ember-standard/import': [2, "always"],
         'ember-standard/logger': [2, "always"],
-        'ember-standard/no-set-in-computed-property': 2
+        'ember-standard/no-set-in-computed-property': 2,
+        'ember-standard/single-destructure': 2
       }
     }
   },
@@ -13,6 +14,7 @@ module.exports = {
     'destructure': require('./rules/destructure'),
     'import': require('./rules/import'),
     'logger': require('./rules/logger'),
-    'no-set-in-computed-property': require('./rules/no-set-in-computed-property')
+    'no-set-in-computed-property': require('./rules/no-set-in-computed-property'),
+    'single-destructure': require('./rules/single-destructure')
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "devDependencies": {
     "babel-eslint": "^7.1.1",
     "eslint": "^3.0.1",
+    "eslint-config-standard": "^6.2.1",
+    "eslint-plugin-promise": "^3.4.0",
+    "eslint-plugin-standard": "^2.0.1",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
     "remark-cli": "^2.1.0",
@@ -27,7 +30,9 @@
     "url": "https://github.com/ciena-blueplanet/eslint-plugin-ember-standard"
   },
   "scripts": {
-    "lint": "remark *.md documentation/**/*.md",
+    "lint": "npm run lint-md && npm run lint-js",
+    "lint-js": "eslint *.js rules/**/*.js tests/**/*.js",
+    "lint-md": "remark *.md documentation/**/*.md",
     "test": "npm run lint && npm run utest",
     "utest": "istanbul cover _mocha -- --recursive tests"
   },

--- a/rules/destructure.js
+++ b/rules/destructure.js
@@ -42,7 +42,7 @@ module.exports = {
     deprecated: false,
     docs: {
       category: 'Stylistic Issues',
-      description: 'enforce destructuring of Ember classes',
+      description: 'Enforce destructuring of Ember classes',
       recommended: true
     },
     schema: [

--- a/rules/import.js
+++ b/rules/import.js
@@ -27,7 +27,7 @@ module.exports = {
     deprecated: false,
     docs: {
       category: 'Stylistic Issues',
-      description: 'enforce import of Ember instead of using global',
+      description: 'Enforce import of Ember instead of using global',
       recommended: true
     },
     schema: [

--- a/rules/logger.js
+++ b/rules/logger.js
@@ -33,7 +33,7 @@ module.exports = {
     deprecated: false,
     docs: {
       category: 'Best Practices',
-      description: 'enforce usage of Ember.Logger over console',
+      description: 'Enforce usage of Ember.Logger over console',
       recommended: true
     },
     schema: [

--- a/rules/single-destructure.js
+++ b/rules/single-destructure.js
@@ -1,0 +1,48 @@
+module.exports = {
+  create: function (context) {
+    var emberVarName = 'Ember'
+    var firstEmberDestructureLocation = null
+
+    return {
+      /**
+       * Get Ember variable name from import statement
+       * @example `import Ember from 'ember'` would yield "Ember"
+       * @example `import Foo from 'ember'` would yield "Foo"
+       * @param {ESLintNode} node - import declaration node
+       */
+      ImportDeclaration: function (node) {
+        if (node.source.value === 'ember') {
+          emberVarName = node.specifiers[0].local.name
+        }
+      },
+
+      /**
+       * Determine if Ember is being destructured when in shouldn't be
+       * @param {ESLintNode} node - variable declarator node
+       */
+      VariableDeclarator: function (node) {
+        if (node.id.type === 'ObjectPattern' && node.init.name === emberVarName) {
+          if (firstEmberDestructureLocation) {
+            var column = firstEmberDestructureLocation.start.column
+            var line = firstEmberDestructureLocation.start.line
+
+            context.report(
+              node,
+              'Do not destructure Ember more than once, merge this with line ' + line + ' column ' + column
+            )
+          } else {
+            firstEmberDestructureLocation = node.parent.loc
+          }
+        }
+      }
+    }
+  },
+  meta: {
+    deprecated: false,
+    docs: {
+      category: 'Stylistic Issues',
+      description: 'Force all destructuring of Ember to occur in one variable declarator',
+      recommended: true
+    }
+  }
+}

--- a/tests/destructure.js
+++ b/tests/destructure.js
@@ -1,5 +1,5 @@
-const RuleTester = require('eslint').RuleTester
-const rule = require('../rules/destructure')
+var RuleTester = require('eslint').RuleTester
+var rule = require('../rules/destructure')
 
 function invalidAlwaysTest (code, name, emberVar) {
   emberVar = emberVar || 'Ember'
@@ -49,7 +49,7 @@ function validNeverTest (code) {
   }
 }
 
-const ruleTester = new RuleTester()
+var ruleTester = new RuleTester()
 
 ruleTester.run('destructure', rule, {
   invalid: [

--- a/tests/import.js
+++ b/tests/import.js
@@ -1,5 +1,5 @@
-const RuleTester = require('eslint').RuleTester
-const rule = require('../rules/import')
+var RuleTester = require('eslint').RuleTester
+var rule = require('../rules/import')
 
 function invalidAlwaysTest (code, emberVarName) {
   return {
@@ -39,7 +39,7 @@ function validAlwaysTest (code) {
   }
 }
 
-const ruleTester = new RuleTester()
+var ruleTester = new RuleTester()
 
 ruleTester.run('import', rule, {
   invalid: [

--- a/tests/logger.js
+++ b/tests/logger.js
@@ -1,5 +1,5 @@
-const RuleTester = require('eslint').RuleTester
-const rule = require('../rules/logger')
+var RuleTester = require('eslint').RuleTester
+var rule = require('../rules/logger')
 
 function invalidAlwaysTest (code, propertyName) {
   return {
@@ -24,7 +24,7 @@ function validAlwaysTest (code) {
   }
 }
 
-const ruleTester = new RuleTester()
+var ruleTester = new RuleTester()
 
 ruleTester.run('logger', rule, {
   invalid: [

--- a/tests/no-set-in-computed-property.js
+++ b/tests/no-set-in-computed-property.js
@@ -1,5 +1,5 @@
-const RuleTester = require('eslint').RuleTester
-const rule = require('../rules/no-set-in-computed-property')
+var RuleTester = require('eslint').RuleTester
+var rule = require('../rules/no-set-in-computed-property')
 
 function invalidAlwaysTest (code, line) {
   return {
@@ -24,7 +24,7 @@ function validAlwaysTest (code) {
   }
 }
 
-const ruleTester = new RuleTester()
+var ruleTester = new RuleTester()
 
 ruleTester.run('no-set-in-computed-property', rule, {
   invalid: [

--- a/tests/single-destructure.js
+++ b/tests/single-destructure.js
@@ -1,0 +1,43 @@
+var RuleTester = require('eslint').RuleTester
+var rule = require('../rules/single-destructure')
+
+function invalidTest (code, firstDestructureLine, firstDestructureColumn, errorLine) {
+  var message = 'Do not destructure Ember more than once, merge this with line ' +
+    firstDestructureLine + ' column ' + firstDestructureColumn
+
+  return {
+    code: code,
+    errors: [
+      {
+        line: errorLine,
+        message: message,
+        type: 'VariableDeclarator'
+      }
+    ],
+    parser: 'babel-eslint'
+  }
+}
+
+function validTest (code) {
+  return {
+    code: code,
+    parser: 'babel-eslint'
+  }
+}
+
+var ruleTester = new RuleTester()
+
+ruleTester.run('single-destructure', rule, {
+  invalid: [
+    invalidTest('import Ember from "ember"; const {Component} = Ember; const {Logger} = Ember', 1, 27, 1),
+    invalidTest('import Foo from "ember"; const {Component} = Foo; const {Logger} = Foo', 1, 25, 1),
+    invalidTest('import Ember from "ember";\nconst {Component} = Ember;\nconst {Logger} = Ember', 2, 0, 3),
+    invalidTest('import Foo from "ember";\nconst {Component} = Foo;\nconst {Logger} = Foo', 2, 0, 3)
+  ],
+  valid: [
+    validTest('import Ember from "ember"; const {Component} = Ember'),
+    validTest('import Foo from "ember"; const {Component} = Foo'),
+    validTest('import Ember from "ember"; const {Component, Logger} = Ember'),
+    validTest('import Foo from "ember"; const {Component, Logger} = Foo')
+  ]
+})


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** new rule: `single-destructure` to prevent destructuring Ember in more than one variable declarator.
