### PR TITLE
Add new rule: computed-property-readonly

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ npm install --save-dev eslint-plugin-ember-standard
 
 ## Rules
 
+*   [computed-property-readonly](documentation/rules/computed-property-readonly.md)
 *   [destructure](documentation/rules/destructure.md)
 *   [import](documentation/rules/import.md)
 *   [logger](documentation/rules/logger.md)

--- a/documentation/rules/computed-property-readonly.md
+++ b/documentation/rules/computed-property-readonly.md
@@ -1,0 +1,1 @@
+# computed-property-readonly

--- a/documentation/rules/computed-property-readonly.md
+++ b/documentation/rules/computed-property-readonly.md
@@ -1,1 +1,81 @@
 # computed-property-readonly
+
+## always
+
+When this rule is given the *always* option it will ensure that computed properties are ALWAYS readOnly.
+
+**ESLint Configuration**
+
+```json
+{
+  "rules": {
+    "ember-standard/computed-property-readonly": [2, "always"]
+  }
+}
+```
+
+**Valid**
+
+```js
+import Ember from 'ember'
+const {Component, computed} = Ember
+
+export default Component.extend({
+  foo: computed('bar', function () {
+    return this.get('bar') + '-baz'
+  }).readOnly()
+})
+```
+
+**Invalid**
+
+```js
+import Ember from 'ember'
+const {Component, computed} = Ember
+
+export default Component.extend({
+  foo: computed('bar', function () {
+    return this.get('bar') + '-baz'
+  })
+})
+```
+
+## never
+
+When this rule given the *never* option it will ensure that computed properties are NEVER readOnly.
+
+**ESLint Configuration**
+
+```json
+{
+  "rules": {
+    "ember-standard/import": [2, "never"]
+  }
+}
+```
+
+**Valid**
+
+```js
+import Ember from 'ember'
+const {Component, computed} = Ember
+
+export default Component.extend({
+  foo: computed('bar', function () {
+    return this.get('bar') + '-baz'
+  })
+})
+```
+
+**Invalid**
+
+```js
+import Ember from 'ember'
+const {Component, computed} = Ember
+
+export default Component.extend({
+  foo: computed('bar', function () {
+    return this.get('bar') + '-baz'
+  }).readOnly()
+})
+```

--- a/documentation/rules/computed-property-readonly.md
+++ b/documentation/rules/computed-property-readonly.md
@@ -1,5 +1,7 @@
 # computed-property-readonly
 
+> NOTE: Currently this rule does not work with [ember-computed-decorators](https://github.com/rwjblue/ember-computed-decorators)
+
 ## always
 
 When this rule is given the *always* option it will ensure that computed properties are ALWAYS readOnly.

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = {
   configs: {
     'ember-standard': {
       rules: {
+        'ember-standard/computed-property-readonly': [2, "always"],
         'ember-standard/destructure': [2, "always"],
         'ember-standard/import': [2, "always"],
         'ember-standard/logger': [2, "always"],
@@ -11,6 +12,7 @@ module.exports = {
     }
   },
   rules: {
+    'computed-property-readonly': require('./rules/computed-property-readonly'),
     'destructure': require('./rules/destructure'),
     'import': require('./rules/import'),
     'logger': require('./rules/logger'),

--- a/rules/computed-property-readonly.js
+++ b/rules/computed-property-readonly.js
@@ -1,0 +1,96 @@
+/**
+ * Report that computed property is not currently readOnly
+ * @param {ESLintContext} context - context
+ * @param {ESLintNode} node - node representing computed property
+ */
+function reportMissingReadOnly (context, node) {
+  context.report({
+    fix: function (fixer) {
+      return fixer.insertTextAfter(node, '.readOnly()')
+    },
+    message: 'Computed property should be readOnly',
+    node: node
+  })
+}
+
+/**
+ * Report that computed property is currently readOnly but shouldn't be
+ * @param {ESLintContext} context - context
+ * @param {ESLintNode} node - node representing computed property
+ */
+function reportUnwantedReadOnly (context, node) {
+  context.report({
+    fix: function (fixer) {
+      var range = node.range
+
+      return fixer.removeRange([
+        range[0] - 1, // Include period
+        range[1] + 2 // Include open and close parens
+      ])
+    },
+    message: 'Computed property should not be readOnly',
+    node: node
+  })
+}
+
+module.exports = {
+  create: function (context) {
+    var emberVarName = 'Ember'
+    var isNever = Boolean(context.options.length > 0 && context.options[0] === 'never')
+
+    return {
+      /**
+       * Determine if readOnly is missing when it shouldn't be or is present
+       * when it shouldn't be
+       * @example `import Ember from 'ember'; console.info('Test')`
+       * @param {ESLintNode} node - call expression node
+       */
+      CallExpression: function (node) {
+        var methodNames = ['alias', 'computed']
+        var isDirectCall = methodNames.indexOf(node.callee.name) !== -1
+
+        var isNestedPropertyCall = (
+          node.callee.property && methodNames.indexOf(node.callee.property.name) !== -1
+        )
+
+        var isReadOnly = node.parent.property && node.parent.property.name === 'readOnly'
+
+        if (isDirectCall || isNestedPropertyCall) {
+          if (isReadOnly && isNever) {
+            reportUnwantedReadOnly(context, node.parent.property)
+          } else if (!isReadOnly && !isNever) {
+            reportMissingReadOnly(context, node.parent)
+          }
+        }
+      },
+
+      /**
+       * Determine if Ember has been explicitly imported
+       * @example `import Ember from 'ember'`
+       * @param {ESLintNode} node - import declaration node
+       */
+      ImportDeclaration: function (node) {
+        if (node.source.value === 'ember') {
+          emberVarName = node.specifiers[0].local.name
+        }
+      }
+    }
+  },
+  meta: {
+    deprecated: false,
+    docs: {
+      category: 'Best Practices',
+      description: 'Ensure that computed properties are readOnly',
+      recommended: true
+    },
+    fixable: 'code',
+    schema: [
+      {
+        enum: [
+          'always',
+          'never'
+        ]
+      }
+    ]
+  }
+}

--- a/tests/computed-property-readonly.js
+++ b/tests/computed-property-readonly.js
@@ -1,0 +1,776 @@
+var RuleTester = require('eslint').RuleTester
+var rule = require('../rules/computed-property-readonly')
+
+var ruleTester = new RuleTester()
+
+ruleTester.run('computed-property-readonly', rule, {
+  invalid: [
+    {
+      code: 'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  })\n' +
+            '})',
+      errors: [
+        {
+          column: 3,
+          line: 2,
+          message: 'Computed property should be readOnly',
+          type: 'Property'
+        }
+      ],
+      options: ['always'],
+      output: 'export default Ember.Component.extend({\n' +
+              '  foo: Ember.computed("bar", function () {\n' +
+              '    return "baz"\n' +
+              '  }).readOnly()\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  })\n' +
+            '})',
+      errors: [
+        {
+          column: 3,
+          line: 3,
+          message: 'Computed property should be readOnly',
+          type: 'Property'
+        }
+      ],
+      options: ['always'],
+      output: 'import Ember from "ember"\n' +
+              'export default Ember.Component.extend({\n' +
+              '  foo: Ember.computed("bar", function () {\n' +
+              '    return "baz"\n' +
+              '  }).readOnly()\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'export default Foo.Component.extend({\n' +
+            '  foo: Foo.computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  })\n' +
+            '})',
+      errors: [
+        {
+          column: 3,
+          line: 3,
+          message: 'Computed property should be readOnly',
+          type: 'Property'
+        }
+      ],
+      options: ['always'],
+      output: 'import Foo from "ember"\n' +
+              'export default Foo.Component.extend({\n' +
+              '  foo: Foo.computed("bar", function () {\n' +
+              '    return "baz"\n' +
+              '  }).readOnly()\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Component, computed} = Ember\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  })\n' +
+            '})',
+      errors: [
+        {
+          column: 3,
+          line: 4,
+          message: 'Computed property should be readOnly',
+          type: 'Property'
+        }
+      ],
+      options: ['always'],
+      output: 'import Ember from "ember"\n' +
+              'const {Component, computed} = Ember\n' +
+              'export default Component.extend({\n' +
+              '  foo: computed("bar", function () {\n' +
+              '    return "baz"\n' +
+              '  }).readOnly()\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'const {Component, computed} = Foo\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  })\n' +
+            '})',
+      errors: [
+        {
+          column: 3,
+          line: 4,
+          message: 'Computed property should be readOnly',
+          type: 'Property'
+        }
+      ],
+      options: ['always'],
+      output: 'import Foo from "ember"\n' +
+              'const {Component, computed} = Foo\n' +
+              'export default Component.extend({\n' +
+              '  foo: computed("bar", function () {\n' +
+              '    return "baz"\n' +
+              '  }).readOnly()\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed.alias("bar")\n' +
+            '})',
+      errors: [
+        {
+          column: 3,
+          line: 2,
+          message: 'Computed property should be readOnly',
+          type: 'Property'
+        }
+      ],
+      options: ['always'],
+      output: 'export default Ember.Component.extend({\n' +
+              '  foo: Ember.computed.alias("bar").readOnly()\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed.alias("bar")\n' +
+            '})',
+      errors: [
+        {
+          column: 3,
+          line: 3,
+          message: 'Computed property should be readOnly',
+          type: 'Property'
+        }
+      ],
+      options: ['always'],
+      output: 'import Ember from "ember"\n' +
+              'export default Ember.Component.extend({\n' +
+              '  foo: Ember.computed.alias("bar").readOnly()\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'export default Foo.Component.extend({\n' +
+            '  foo: Foo.computed.alias("bar")\n' +
+            '})',
+      errors: [
+        {
+          column: 3,
+          line: 3,
+          message: 'Computed property should be readOnly',
+          type: 'Property'
+        }
+      ],
+      options: ['always'],
+      output: 'import Foo from "ember"\n' +
+              'export default Foo.Component.extend({\n' +
+              '  foo: Foo.computed.alias("bar").readOnly()\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Component, computed} = Ember\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed.alias("bar")\n' +
+            '})',
+      errors: [
+        {
+          column: 3,
+          line: 4,
+          message: 'Computed property should be readOnly',
+          type: 'Property'
+        }
+      ],
+      options: ['always'],
+      output: 'import Ember from "ember"\n' +
+              'const {Component, computed} = Ember\n' +
+              'export default Component.extend({\n' +
+              '  foo: computed.alias("bar").readOnly()\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'const {Component, computed} = Foo\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed.alias("bar")\n' +
+            '})',
+      errors: [
+        {
+          column: 3,
+          line: 4,
+          message: 'Computed property should be readOnly',
+          type: 'Property'
+        }
+      ],
+      options: ['always'],
+      output: 'import Foo from "ember"\n' +
+              'const {Component, computed} = Foo\n' +
+              'export default Component.extend({\n' +
+              '  foo: computed.alias("bar").readOnly()\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  }).readOnly()\n' +
+            '})',
+      errors: [
+        {
+          column: 6,
+          line: 4,
+          message: 'Computed property should not be readOnly',
+          type: 'Identifier'
+        }
+      ],
+      options: ['never'],
+      output: 'export default Ember.Component.extend({\n' +
+              '  foo: Ember.computed("bar", function () {\n' +
+              '    return "baz"\n' +
+              '  })\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  }).readOnly()\n' +
+            '})',
+      errors: [
+        {
+          column: 6,
+          line: 5,
+          message: 'Computed property should not be readOnly',
+          type: 'Identifier'
+        }
+      ],
+      options: ['never'],
+      output: 'import Ember from "ember"\n' +
+              'export default Ember.Component.extend({\n' +
+              '  foo: Ember.computed("bar", function () {\n' +
+              '    return "baz"\n' +
+              '  })\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'export default Foo.Component.extend({\n' +
+            '  foo: Foo.computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  }).readOnly()\n' +
+            '})',
+      errors: [
+        {
+          column: 6,
+          line: 5,
+          message: 'Computed property should not be readOnly',
+          type: 'Identifier'
+        }
+      ],
+      options: ['never'],
+      output: 'import Foo from "ember"\n' +
+              'export default Foo.Component.extend({\n' +
+              '  foo: Foo.computed("bar", function () {\n' +
+              '    return "baz"\n' +
+              '  })\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Component, computed} = Ember\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  }).readOnly()\n' +
+            '})',
+      errors: [
+        {
+          column: 6,
+          line: 6,
+          message: 'Computed property should not be readOnly',
+          type: 'Identifier'
+        }
+      ],
+      options: ['never'],
+      output: 'import Ember from "ember"\n' +
+              'const {Component, computed} = Ember\n' +
+              'export default Component.extend({\n' +
+              '  foo: computed("bar", function () {\n' +
+              '    return "baz"\n' +
+              '  })\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'const {Component, computed} = Foo\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  }).readOnly()\n' +
+            '})',
+      errors: [
+        {
+          column: 6,
+          line: 6,
+          message: 'Computed property should not be readOnly',
+          type: 'Identifier'
+        }
+      ],
+      options: ['never'],
+      output: 'import Foo from "ember"\n' +
+              'const {Component, computed} = Foo\n' +
+              'export default Component.extend({\n' +
+              '  foo: computed("bar", function () {\n' +
+              '    return "baz"\n' +
+              '  })\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed.alias("bar").readOnly()\n' +
+            '})',
+      errors: [
+        {
+          column: 36,
+          line: 2,
+          message: 'Computed property should not be readOnly',
+          type: 'Identifier'
+        }
+      ],
+      options: ['never'],
+      output: 'export default Ember.Component.extend({\n' +
+              '  foo: Ember.computed.alias("bar")\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed.alias("bar").readOnly()\n' +
+            '})',
+      errors: [
+        {
+          column: 36,
+          line: 3,
+          message: 'Computed property should not be readOnly',
+          type: 'Identifier'
+        }
+      ],
+      options: ['never'],
+      output: 'import Ember from "ember"\n' +
+              'export default Ember.Component.extend({\n' +
+              '  foo: Ember.computed.alias("bar")\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'export default Foo.Component.extend({\n' +
+            '  foo: Foo.computed.alias("bar").readOnly()\n' +
+            '})',
+      errors: [
+        {
+          column: 34,
+          line: 3,
+          message: 'Computed property should not be readOnly',
+          type: 'Identifier'
+        }
+      ],
+      options: ['never'],
+      output: 'import Foo from "ember"\n' +
+              'export default Foo.Component.extend({\n' +
+              '  foo: Foo.computed.alias("bar")\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Component, computed} = Ember\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed.alias("bar").readOnly()\n' +
+            '})',
+      errors: [
+        {
+          column: 30,
+          line: 4,
+          message: 'Computed property should not be readOnly',
+          type: 'Identifier'
+        }
+      ],
+      options: ['never'],
+      output: 'import Ember from "ember"\n' +
+              'const {Component, computed} = Ember\n' +
+              'export default Component.extend({\n' +
+              '  foo: computed.alias("bar")\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'const {Component, computed} = Foo\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed.alias("bar").readOnly()\n' +
+            '})',
+      errors: [
+        {
+          column: 30,
+          line: 4,
+          message: 'Computed property should not be readOnly',
+          type: 'Identifier'
+        }
+      ],
+      options: ['never'],
+      output: 'import Foo from "ember"\n' +
+              'const {Component, computed} = Foo\n' +
+              'export default Component.extend({\n' +
+              '  foo: computed.alias("bar")\n' +
+              '})',
+      parser: 'babel-eslint'
+    }
+  ],
+  valid: [
+    {
+      code: 'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  }).readOnly()\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  }).readOnly()\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'export default Foo.Component.extend({\n' +
+            '  foo: Foo.computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  }).readOnly()\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Component, computed} = Ember\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  }).readOnly()\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'const {Component, computed} = Foo\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  }).readOnly()\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed.oneWay("bar")\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed.oneWay("bar")\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'export default Foo.Component.extend({\n' +
+            '  foo: Foo.computed.oneWay("bar")\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Component, computed} = Ember\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed.oneWay("bar")\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'const {Component, computed} = Foo\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed.oneWay("bar")\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed.readOnly("bar")\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed.readOnly("bar")\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'export default Foo.Component.extend({\n' +
+            '  foo: Foo.computed.readOnly("bar")\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Component, computed} = Ember\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed.readOnly("bar")\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'const {Component, computed} = Foo\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed.readOnly("bar")\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed.alias("bar").readOnly()\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed.alias("bar").readOnly()\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'export default Foo.Component.extend({\n' +
+            '  foo: Foo.computed.alias("bar").readOnly()\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Component, computed} = Ember\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed.alias("bar").readOnly()\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'const {Component, computed} = Foo\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed.alias("bar").readOnly()\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  })\n' +
+            '})',
+      options: ['never'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  })\n' +
+            '})',
+      options: ['never'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'export default Foo.Component.extend({\n' +
+            '  foo: Foo.computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  })\n' +
+            '})',
+      options: ['never'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Component, computed} = Ember\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  })\n' +
+            '})',
+      options: ['never'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'const {Component, computed} = Foo\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  })\n' +
+            '})',
+      options: ['never'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed.oneWay("bar")\n' +
+            '})',
+      options: ['never'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed.oneWay("bar")\n' +
+            '})',
+      options: ['never'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'export default Foo.Component.extend({\n' +
+            '  foo: Foo.computed.oneWay("bar")\n' +
+            '})',
+      options: ['never'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Component, computed} = Ember\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed.oneWay("bar")\n' +
+            '})',
+      options: ['never'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'const {Component, computed} = Foo\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed.oneWay("bar")\n' +
+            '})',
+      options: ['never'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed.alias("bar")\n' +
+            '})',
+      options: ['never'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed.alias("bar")\n' +
+            '})',
+      options: ['never'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'export default Foo.Component.extend({\n' +
+            '  foo: Foo.computed.alias("bar")\n' +
+            '})',
+      options: ['never'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Component, computed} = Ember\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed.alias("bar")\n' +
+            '})',
+      options: ['never'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'const {Component, computed} = Foo\n' +
+            'export default Component.extend({\n' +
+            '  foo: computed.alias("bar")\n' +
+            '})',
+      options: ['never'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "from"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  foo: Ember.computed("bar", function () {\n' +
+            '    return "baz"\n' +
+            '  }).readOnly()\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    }
+  ]
+})


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** new rule `computed-property-readonly` for ensuring computed properties are always readOnly or never readOnly.
