### PR TITLE
Fixed computed-property-readonly rule to support ember-computed-decorators

### DIFF
--- a/documentation/rules/computed-property-readonly.md
+++ b/documentation/rules/computed-property-readonly.md
@@ -1,7 +1,5 @@
 # computed-property-readonly
 
-> NOTE: Currently this rule does not work with [ember-computed-decorators](https://github.com/rwjblue/ember-computed-decorators)
-
 ## always
 
 When this rule is given the *always* option it will ensure that computed properties are ALWAYS readOnly.
@@ -29,6 +27,20 @@ export default Component.extend({
 })
 ```
 
+```js
+import Ember from 'ember'
+const {Component} = Ember
+import computed, {readOnly} from 'ember-computed-decorators'
+
+export default Component.extend({
+  @readOnly
+  @computed('bar')
+  foo (bar) {
+    return bar + '-baz'
+  }
+})
+```
+
 **Invalid**
 
 ```js
@@ -39,6 +51,19 @@ export default Component.extend({
   foo: computed('bar', function () {
     return this.get('bar') + '-baz'
   })
+})
+```
+
+```js
+import Ember from 'ember'
+const {Component} = Ember
+import computed, {readOnly} from 'ember-computed-decorators'
+
+export default Component.extend({
+  @computed('bar')
+  foo (bar) {
+    return bar + '-baz'
+  }
 })
 ```
 
@@ -69,6 +94,19 @@ export default Component.extend({
 })
 ```
 
+```js
+import Ember from 'ember'
+const {Component} = Ember
+import computed, {readOnly} from 'ember-computed-decorators'
+
+export default Component.extend({
+  @computed('bar')
+  foo (bar) {
+    return bar + '-baz'
+  }
+})
+```
+
 **Invalid**
 
 ```js
@@ -79,5 +117,19 @@ export default Component.extend({
   foo: computed('bar', function () {
     return this.get('bar') + '-baz'
   }).readOnly()
+})
+```
+
+```js
+import Ember from 'ember'
+const {Component} = Ember
+import computed, {readOnly} from 'ember-computed-decorators'
+
+export default Component.extend({
+  @readOnly
+  @computed('bar')
+  foo (bar) {
+    return bar + '-baz'
+  }
 })
 ```

--- a/rules/computed-property-readonly.js
+++ b/rules/computed-property-readonly.js
@@ -14,6 +14,24 @@ function reportMissingReadOnly (context, node) {
 }
 
 /**
+ * Report that computed property is not currently readOnly
+ * @param {ESLintContext} context - context
+ * @param {ESLintNode} node - node representing computed decorator
+ */
+function reportMissingReadOnlyDecorator (context, node) {
+  context.report({
+    fix: function (fixer) {
+      var computedDecoratorLine = context.getSourceCode().lines[node.parent.loc.start.line - 1]
+      var leadingWhiteSpace = computedDecoratorLine.replace(/^(\s*).*$/, '$1')
+
+      return fixer.insertTextBefore(node.parent, '@readOnly\n' + leadingWhiteSpace)
+    },
+    message: 'Computed property should be readOnly',
+    node: node.parent.parent
+  })
+}
+
+/**
  * Report that computed property is currently readOnly but shouldn't be
  * @param {ESLintContext} context - context
  * @param {ESLintNode} node - node representing computed property
@@ -33,45 +51,69 @@ function reportUnwantedReadOnly (context, node) {
   })
 }
 
+/**
+ * Process computed call expression
+ * @param {ESLintContext} context - context
+ * @param {ESLintNode} node - call expression node
+ * @param {Boolean} isNever - whether or not "never" option is set
+ */
+function processComputed (context, node, isNever) {
+  var methodNames = ['alias', 'computed']
+  var isDirectCall = methodNames.indexOf(node.callee.name) !== -1
+
+  var isNestedPropertyCall = (
+    node.callee.property && methodNames.indexOf(node.callee.property.name) !== -1
+  )
+
+  var isReadOnly = node.parent.property && node.parent.property.name === 'readOnly'
+
+  if (isDirectCall || isNestedPropertyCall) {
+    if (isReadOnly && isNever) {
+      reportUnwantedReadOnly(context, node.parent.property)
+    } else if (!isReadOnly && !isNever) {
+      reportMissingReadOnly(context, node.parent)
+    }
+  }
+}
+
+/**
+ * Process computed decorator call expression
+ * @param {ESLintContext} context - context
+ * @param {ESLintNode} node - call expression node
+ * @param {Boolean} isNever - whether or not "never" option is set
+ */
+function processComputedDecorator (context, node, isNever) {
+  var readOnlyDecorator = null
+
+  node.parent.parent.decorators
+    .forEach(function (decorator) {
+      if (decorator.expression.name === 'readOnly') {
+        readOnlyDecorator = decorator
+      }
+    })
+
+  if (readOnlyDecorator && isNever) {
+    reportUnwantedReadOnly(context, readOnlyDecorator)
+  } else if (!readOnlyDecorator && !isNever) {
+    reportMissingReadOnlyDecorator(context, node)
+  }
+}
+
 module.exports = {
   create: function (context) {
-    var emberVarName = 'Ember'
     var isNever = Boolean(context.options.length > 0 && context.options[0] === 'never')
 
     return {
       /**
        * Determine if readOnly is missing when it shouldn't be or is present
        * when it shouldn't be
-       * @example `import Ember from 'ember'; console.info('Test')`
        * @param {ESLintNode} node - call expression node
        */
       CallExpression: function (node) {
-        var methodNames = ['alias', 'computed']
-        var isDirectCall = methodNames.indexOf(node.callee.name) !== -1
-
-        var isNestedPropertyCall = (
-          node.callee.property && methodNames.indexOf(node.callee.property.name) !== -1
-        )
-
-        var isReadOnly = node.parent.property && node.parent.property.name === 'readOnly'
-
-        if (isDirectCall || isNestedPropertyCall) {
-          if (isReadOnly && isNever) {
-            reportUnwantedReadOnly(context, node.parent.property)
-          } else if (!isReadOnly && !isNever) {
-            reportMissingReadOnly(context, node.parent)
-          }
-        }
-      },
-
-      /**
-       * Determine if Ember has been explicitly imported
-       * @example `import Ember from 'ember'`
-       * @param {ESLintNode} node - import declaration node
-       */
-      ImportDeclaration: function (node) {
-        if (node.source.value === 'ember') {
-          emberVarName = node.specifiers[0].local.name
+        if (node.parent.type === 'Decorator') {
+          processComputedDecorator(context, node, isNever)
+        } else {
+          processComputed(context, node, isNever)
         }
       }
     }

--- a/tests/computed-property-readonly.js
+++ b/tests/computed-property-readonly.js
@@ -452,7 +452,61 @@ ruleTester.run('computed-property-readonly', rule, {
               '  foo: computed.alias("bar")\n' +
               '})',
       parser: 'babel-eslint'
-    }
+    },
+    {
+      code: 'import computed, {readOnly} from "ember-computed-decorators"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  @computed("bar")\n' +
+            '  foo (bar) {\n' +
+            '    return "baz"\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 3,
+          line: 4,
+          message: 'Computed property should be readOnly',
+          type: 'Property'
+        }
+      ],
+      options: ['always'],
+      output: 'import computed, {readOnly} from "ember-computed-decorators"\n' +
+              'export default Ember.Component.extend({\n' +
+              '  @readOnly\n' +
+              '  @computed("bar")\n' +
+              '  foo (bar) {\n' +
+              '    return "baz"\n' +
+              '  }\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import computed, {readOnly} from "ember-computed-decorators"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  @readOnly\n' +
+            '  @computed("bar")\n' +
+            '  foo (bar) {\n' +
+            '    return "baz"\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 3,
+          line: 3,
+          message: 'Computed property should not be readOnly',
+          type: 'Decorator'
+        }
+      ],
+      options: ['never'],
+      output: 'import computed, {readOnly} from "ember-computed-decorators"\n' +
+              'export default Ember.Component.extend({\n' +
+              '  @computed("bar")\n' +
+              '  foo (bar) {\n' +
+              '    return "baz"\n' +
+              '  }\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
   ],
   valid: [
     {
@@ -763,13 +817,36 @@ ruleTester.run('computed-property-readonly', rule, {
       parser: 'babel-eslint'
     },
     {
-      code: 'import Foo from "from"\n' +
+      code: 'import Foo from "foo"\n' +
             'export default Ember.Component.extend({\n' +
             '  foo: Ember.computed("bar", function () {\n' +
             '    return "baz"\n' +
             '  }).readOnly()\n' +
             '})',
       options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import computed, {readOnly} from "ember-computed-decorators"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  @readOnly\n' +
+            '  @computed("bar")\n' +
+            '  foo (bar) {\n' +
+            '    return "baz"\n' +
+            '  }\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import computed, {readOnly} from "ember-computed-decorators"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  @computed("bar")\n' +
+            '  foo (bar) {\n' +
+            '    return "baz"\n' +
+            '  }\n' +
+            '})',
+      options: ['never'],
       parser: 'babel-eslint'
     }
   ]


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** `computed-property-readonly` rule to support [ember-computed-decorators](https://github.com/rwjblue/ember-computed-decorators).
