### PR TITLE
Add no-settimeout rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,21 @@ npm install --save-dev eslint-plugin-ember-standard
 
 ## Rules
 
-*   [computed-property-readonly](documentation/rules/computed-property-readonly.md)
-*   [destructure](documentation/rules/destructure.md)
-*   [import](documentation/rules/import.md)
-*   [logger](documentation/rules/logger.md)
-*   [no-set-in-computed-property](documentation/rules/no-set-in-computed-property.md)
-*   [single-destructure](documentation/rules/single-destructure.md)
+### Possible Errors
+
+*   [no-set-in-computed-property](documentation/rules/no-set-in-computed-property.md) – Prevent side effects.
+* [no-settimeout](documentation/rules/no-settimeout.md) – Make run loop aware of timeouts.
+
+### Best Practices
+
+*   [computed-property-readonly](documentation/rules/computed-property-readonly.md) – Enforce data down, actions up.
+*   [logger](documentation/rules/logger.md) – Make sure logging goes through Ember.
+
+### Stylistic Issues
+
+*   [destructure](documentation/rules/destructure.md) – Make sure Ember properties are destructured.
+*   [import](documentation/rules/import.md) – Make sure Ember is explicitly imported.
+*   [single-destructure](documentation/rules/single-destructure.md) – Make sure Ember properties are destructured in a single variable declaration.
 
 [bithound-img]: https://www.bithound.io/github/ciena-blueplanet/eslint-plugin-ember-standard/badges/score.svg "bitHound"
 [bithound-url]: https://www.bithound.io/github/ciena-blueplanet/eslint-plugin-ember-standard

--- a/documentation/rules/no-settimeout.md
+++ b/documentation/rules/no-settimeout.md
@@ -1,0 +1,44 @@
+# no-settimeout
+
+This rule ensures no calls to `setTimeout()` are made.
+
+**ESLint Configuration**
+
+```json
+{
+  "rules": {
+    "ember-standard/no-settimeout": 2
+  }
+}
+```
+
+**Valid**
+
+```js
+import Ember from 'ember'
+const {run} = Ember
+
+run.later(this, () => {
+  // do something
+}, 100)
+```
+
+```js
+setTimeout(() => {
+  // do something
+}, 100)
+```
+
+> Note: In the above `setTimeout` is valid because Ember has not been imported.
+This serves useful in an Ember project for files outside of the normal app/addon
+files.
+
+**Invalid**
+
+```js
+import Ember from 'ember'
+
+setTimeout(() => {
+  // do something
+}, 100)
+```

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = {
         'ember-standard/import': [2, "always"],
         'ember-standard/logger': [2, "always"],
         'ember-standard/no-set-in-computed-property': 2,
+        'ember-standard/no-settimeout': 2,
         'ember-standard/single-destructure': 2
       }
     }
@@ -17,6 +18,7 @@ module.exports = {
     'import': require('./rules/import'),
     'logger': require('./rules/logger'),
     'no-set-in-computed-property': require('./rules/no-set-in-computed-property'),
+    'no-settimeout': require('./rules/no-settimeout'),
     'single-destructure': require('./rules/single-destructure')
   }
 }

--- a/rules/logger.js
+++ b/rules/logger.js
@@ -10,8 +10,8 @@ var VALID_LOGGER_METHODS = [
 module.exports = {
   create: function (context) {
     var emberVarName = null
-    var isLoggerDestructured = false
     var isNever = Boolean(context.options.length > 0 && context.options[0] === 'never')
+    var loggerVarName = null
 
     return {
       /**
@@ -28,7 +28,7 @@ module.exports = {
           VALID_LOGGER_METHODS.indexOf(node.callee.property.name) !== -1
         ) {
           var propertyName = node.callee.property.name
-          var replacement = (isLoggerDestructured ? 'Logger' : emberVarName + '.Logger')
+          var replacement = loggerVarName || emberVarName + '.Logger'
 
           context.report({
             fix: function (fixer) {
@@ -63,7 +63,7 @@ module.exports = {
         ) {
           node.id.properties.forEach(function (property) {
             if (property.key.name === 'Logger') {
-              isLoggerDestructured = true
+              loggerVarName = property.value.name
             }
           })
         }

--- a/rules/no-settimeout.js
+++ b/rules/no-settimeout.js
@@ -1,0 +1,69 @@
+module.exports = {
+  create: function (context) {
+    var emberVarName = null
+    var runVarName = null
+
+    return {
+      /**
+       * Determine if setTimeout is being used
+       * @example `import Ember from 'ember'; setTimeout(() => {}, 100)`
+       * @param {ESLintNode} node - call expression node
+       */
+      CallExpression: function (node) {
+        if (!emberVarName || node.callee.name !== 'setTimeout') {
+          return
+        }
+
+        var methodCall = (runVarName || emberVarName + '.run') + '.later'
+        var argsPlusCloseParen = this.getSourceCode().getText().slice(node.callee.end + 1, node.end)
+
+        context.report({
+          fix: function (fixer) {
+            return fixer.replaceText(node, methodCall + '(this, ' + argsPlusCloseParen)
+          },
+          message: 'Use ' + methodCall + ' instead of setTimeout',
+          node: node
+        })
+      },
+
+      /**
+       * Get Ember variable name from import statement
+       * @example `import Ember from 'ember'` would yield "Ember"
+       * @example `import Foo from 'ember'` would yield "Foo"
+       * @param {ESLintNode} node - import declaration node
+       */
+      ImportDeclaration: function (node) {
+        if (node.source.value === 'ember') {
+          emberVarName = node.specifiers[0].local.name
+        }
+      },
+
+      /**
+       * Determine if run has been destructured or not
+       * @param {ESLintNode} node - variable declarator node
+       */
+      VariableDeclarator: function (node) {
+        if (
+          node.id.type === 'ObjectPattern' &&
+          node.init.name === emberVarName &&
+          node.id.properties.length !== 0
+        ) {
+          node.id.properties.forEach(function (property) {
+            if (property.key.name === 'run') {
+              runVarName = property.value.name
+            }
+          })
+        }
+      }
+    }
+  },
+  meta: {
+    deprecated: false,
+    docs: {
+      category: 'Possible Errors',
+      description: 'Prevent usage of setTimeout',
+      recommended: true
+    },
+    fixable: 'code'
+  }
+}

--- a/tests/logger.js
+++ b/tests/logger.js
@@ -292,6 +292,34 @@ ruleTester.run('logger', rule, {
       options: ['always'],
       output: 'import Foo from "ember"; const {Logger} = Foo; Logger.warn("Test")',
       parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"; const {Logger: Logga} = Ember; console.warn("Test")',
+      errors: [
+        {
+          column: 59,
+          line: 1,
+          message: 'Use Logga instead of console',
+          type: 'Identifier'
+        }
+      ],
+      options: ['always'],
+      output: 'import Ember from "ember"; const {Logger: Logga} = Ember; Logga.warn("Test")',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"; const {Logger: Logga} = Foo; console.warn("Test")',
+      errors: [
+        {
+          column: 55,
+          line: 1,
+          message: 'Use Logga instead of console',
+          type: 'Identifier'
+        }
+      ],
+      options: ['always'],
+      output: 'import Foo from "ember"; const {Logger: Logga} = Foo; Logga.warn("Test")',
+      parser: 'babel-eslint'
     }
   ],
   valid: [

--- a/tests/no-settimeout.js
+++ b/tests/no-settimeout.js
@@ -134,7 +134,69 @@ ruleTester.run('no-settimeout', rule, {
               'runna.later(this, () => {}, 100)\n' +
               'runna.later(this, () => {console.info("test")}, 321)',
       parser: 'babel-eslint'
-    }
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'import run from "run"\n' +
+            'setTimeout(() => {}, 100)',
+      errors: [
+        {
+          column: 1,
+          line: 3,
+          message: 'Use Ember.run.later instead of setTimeout',
+          type: 'CallExpression'
+        }
+      ],
+      options: ['always'],
+      output: 'import Ember from "ember"\n' +
+              'import run from "run"\n' +
+              'Ember.run.later(this, () => {}, 100)',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const run = "test"\n' +
+            'setTimeout(() => {}, 100)',
+      errors: [
+        {
+          column: 1,
+          line: 3,
+          message: 'Use Ember.run.later instead of setTimeout',
+          type: 'CallExpression'
+        }
+      ],
+      options: ['always'],
+      output: 'import Ember from "ember"\n' +
+              'const run = "test"\n' +
+              'Ember.run.later(this, () => {}, 100)',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'const {Logger, run: runna} = Foo\n' +
+            'setTimeout(() => {}, 100)\n' +
+            'setTimeout(() => {console.info("test")}, 321)',
+      errors: [
+        {
+          column: 1,
+          line: 3,
+          message: 'Use runna.later instead of setTimeout',
+          type: 'CallExpression'
+        },
+        {
+          column: 1,
+          line: 4,
+          message: 'Use runna.later instead of setTimeout',
+          type: 'CallExpression'
+        }
+      ],
+      options: ['always'],
+      output: 'import Foo from "ember"\n' +
+              'const {Logger, run: runna} = Foo\n' +
+              'runna.later(this, () => {}, 100)\n' +
+              'runna.later(this, () => {console.info("test")}, 321)',
+      parser: 'babel-eslint'
+    },
   ],
   valid: [
     {

--- a/tests/no-settimeout.js
+++ b/tests/no-settimeout.js
@@ -1,0 +1,177 @@
+var RuleTester = require('eslint').RuleTester
+var rule = require('../rules/no-settimeout')
+
+var ruleTester = new RuleTester()
+
+ruleTester.run('no-settimeout', rule, {
+  invalid: [
+    {
+      code: 'import Ember from "ember"\n' +
+            'setTimeout(() => {}, 100)',
+      errors: [
+        {
+          column: 1,
+          line: 2,
+          message: 'Use Ember.run.later instead of setTimeout',
+          type: 'CallExpression'
+        }
+      ],
+      options: ['always'],
+      output: 'import Ember from "ember"\n' +
+              'Ember.run.later(this, () => {}, 100)',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'setTimeout(() => {}, 100)',
+      errors: [
+        {
+          column: 1,
+          line: 2,
+          message: 'Use Foo.run.later instead of setTimeout',
+          type: 'CallExpression'
+        }
+      ],
+      options: ['always'],
+      output: 'import Foo from "ember"\n' +
+              'Foo.run.later(this, () => {}, 100)',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {run} = Ember\n' +
+            'setTimeout(() => {}, 100)',
+      errors: [
+        {
+          column: 1,
+          line: 3,
+          message: 'Use run.later instead of setTimeout',
+          type: 'CallExpression'
+        }
+      ],
+      options: ['always'],
+      output: 'import Ember from "ember"\n' +
+              'const {run} = Ember\n' +
+              'run.later(this, () => {}, 100)',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'const {run} = Foo\n' +
+            'setTimeout(() => {}, 100)',
+      errors: [
+        {
+          column: 1,
+          line: 3,
+          message: 'Use run.later instead of setTimeout',
+          type: 'CallExpression'
+        }
+      ],
+      options: ['always'],
+      output: 'import Foo from "ember"\n' +
+              'const {run} = Foo\n' +
+              'run.later(this, () => {}, 100)',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {run: runna} = Ember\n' +
+            'setTimeout(() => {}, 100)',
+      errors: [
+        {
+          column: 1,
+          line: 3,
+          message: 'Use runna.later instead of setTimeout',
+          type: 'CallExpression'
+        }
+      ],
+      options: ['always'],
+      output: 'import Ember from "ember"\n' +
+              'const {run: runna} = Ember\n' +
+              'runna.later(this, () => {}, 100)',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'const {run: runna} = Foo\n' +
+            'setTimeout(() => {}, 100)',
+      errors: [
+        {
+          column: 1,
+          line: 3,
+          message: 'Use runna.later instead of setTimeout',
+          type: 'CallExpression'
+        }
+      ],
+      options: ['always'],
+      output: 'import Foo from "ember"\n' +
+              'const {run: runna} = Foo\n' +
+              'runna.later(this, () => {}, 100)',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'const {run: runna} = Foo\n' +
+            'setTimeout(() => {}, 100)\n' +
+            'setTimeout(() => {console.info("test")}, 321)',
+      errors: [
+        {
+          column: 1,
+          line: 3,
+          message: 'Use runna.later instead of setTimeout',
+          type: 'CallExpression'
+        },
+        {
+          column: 1,
+          line: 4,
+          message: 'Use runna.later instead of setTimeout',
+          type: 'CallExpression'
+        }
+      ],
+      options: ['always'],
+      output: 'import Foo from "ember"\n' +
+              'const {run: runna} = Foo\n' +
+              'runna.later(this, () => {}, 100)\n' +
+              'runna.later(this, () => {console.info("test")}, 321)',
+      parser: 'babel-eslint'
+    }
+  ],
+  valid: [
+    {
+      code: 'setTimeout(() => {}, 100)',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'Ember.run.later(this, () => {})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'Ember.run.later(this, () => {})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'Foo.run.later(this, () => {})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {run} = Ember\n' +
+            'run.later(this, () => {})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"\n' +
+            'const {run} = Foo\n' +
+            'run.later(this, () => {})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    }
+  ]
+})


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** `no-settimeout` rule to ensure no calls to `setTimeout()` are made.
