### PR TITLE
Add new prop-types rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ npm install --save-dev eslint-plugin-ember-standard
 
 *   [no-set-in-computed-property](documentation/rules/no-set-in-computed-property.md) – Prevent side effects.
 * [no-settimeout](documentation/rules/no-settimeout.md) – Make run loop aware of timeouts.
+* [prop-types](documentation/rules/prop-types.md) – Make sure `PropTypes` references are valid.
 
 ### Best Practices
 

--- a/documentation/rules/prop-types.md
+++ b/documentation/rules/prop-types.md
@@ -1,1 +1,64 @@
 # prop-types
+
+**Valid**
+
+```js
+import Ember from 'ember'
+const {Component} = Ember
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
+
+export default Component.extend(PropTypeMixin, {
+  propTypes: {
+    alpha: PropTypes.any,
+    bravo: PropTypes.array,
+    charlie: PropTypes.arrayOf(PropTypes.string),
+    delta: PropTypes.bool,
+    echo: PropTypes.element,
+    foxtrot: PropTypes.EmberObject,
+    golf: PropTypes.func,
+    hotel: PropTypes.instanceOf(HTMLElement),
+    india: PropTypes.null,
+    juliett: PropTypes.number,
+    kilo: PropTypes.object,
+    lima: PropTypes.oneOf(['foo', 'bar']),
+    mike: PropTypes.oneOfType([
+      PropTypes.null,
+      PropTypes.string
+    ]),
+    november: PropTypes.shape({
+      foo: PropTypes.string
+    }),
+    oscar: PropTypes.string,
+    papa: PropTypes.symbol
+  }
+})
+```
+
+**Invalid**
+
+```js
+import Ember from 'ember'
+const {Component} = Ember
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
+
+export default Component.extend(PropTypeMixin, {
+  propTypes: {
+    alpha: PropTypes.any(),
+    bravo: PropTypes.array(),
+    charlie: PropTypes.arrayOf,
+    delta: PropTypes.bool(),
+    echo: PropTypes.element(),
+    foxtrot: PropTypes.EmberObject(),
+    golf: PropTypes.func(),
+    hotel: PropTypes.instanceOf,
+    india: PropTypes.null(),
+    juliett: PropTypes.number(),
+    kilo: PropTypes.object(),
+    lima: PropTypes.oneOf
+    mike: PropTypes.oneOfType,
+    november: PropTypes.shape,
+    oscar: PropTypes.string(),
+    papa: PropTypes.symbol()
+  }
+})
+```

--- a/documentation/rules/prop-types.md
+++ b/documentation/rules/prop-types.md
@@ -1,0 +1,1 @@
+# prop-types

--- a/documentation/rules/prop-types.md
+++ b/documentation/rules/prop-types.md
@@ -1,5 +1,7 @@
 # prop-types
 
+This rule ensures `PropTypes` are valid given the API provided by [ember-prop-types](http://ciena-blueplanet.github.io/ember-prop-types/).
+
 **Valid**
 
 ```js

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = {
         'ember-standard/logger': [2, "always"],
         'ember-standard/no-set-in-computed-property': 2,
         'ember-standard/no-settimeout': 2,
+        'ember-standard/prop-types': 2,
         'ember-standard/single-destructure': 2
       }
     }
@@ -19,6 +20,7 @@ module.exports = {
     'logger': require('./rules/logger'),
     'no-set-in-computed-property': require('./rules/no-set-in-computed-property'),
     'no-settimeout': require('./rules/no-settimeout'),
+    'prop-types': require('./rules/prop-types'),
     'single-destructure': require('./rules/single-destructure')
   }
 }

--- a/rules/prop-types.js
+++ b/rules/prop-types.js
@@ -1,0 +1,139 @@
+function basicPropertyValidator (context, node) {
+  if (
+    node.parent.type === 'CallExpression' &&
+    node.parent.callee.property === node.property
+  ) {
+    context.report({
+      message: node.property.name + ' should not be a call expression',
+      node: node.property
+    })
+  }
+}
+
+function functionWithOneArgValidator (context, node) {
+  if (
+    node.parent.type !== 'CallExpression' ||
+    node.parent.callee.property !== node.property
+  ) {
+    context.report({
+      message: node.property.name + ' should be a call expression',
+      node: node.property
+    })
+
+    return true
+  }
+
+  if (node.parent.arguments.length !== 1) {
+    context.report({
+      message: node.property.name + ' call expression should only have one argument',
+      node: node.parent
+    })
+
+    return true
+  }
+
+  return false
+}
+
+function functionWithArrayArgValidator (context, node) {
+  if (functionWithOneArgValidator(context, node)) {
+    return
+  }
+
+  if (node.parent.arguments[0].type !== 'ArrayExpression') {
+    context.report({
+      message: 'argument should be an array expression',
+      node: node.parent.arguments[0]
+    })
+  }
+}
+
+function functionWithObjectArgValidator (context, node) {
+  if (functionWithOneArgValidator(context, node)) {
+    return
+  }
+
+  if (node.parent.arguments[0].type !== 'ObjectExpression') {
+    context.report({
+      message: 'argument should be an object expression',
+      node: node.parent.arguments[0]
+    })
+  }
+}
+
+var propertyValidators = {
+  any: basicPropertyValidator,
+  array: basicPropertyValidator,
+  arrayOf: functionWithOneArgValidator,
+  bool: basicPropertyValidator,
+  element: basicPropertyValidator,
+  EmberObject: basicPropertyValidator,
+  func: basicPropertyValidator,
+  instanceOf: functionWithOneArgValidator,
+  null: basicPropertyValidator,
+  number: basicPropertyValidator,
+  object: basicPropertyValidator,
+  oneOf: functionWithArrayArgValidator,
+  oneOfType: functionWithArrayArgValidator,
+  shape: functionWithObjectArgValidator,
+  string: basicPropertyValidator,
+  symbol: basicPropertyValidator
+}
+
+module.exports = {
+  create: function (context) {
+    var propTypesVarName = null
+
+    return {
+      /**
+       * Validate PropType properties
+       * @param {ESLintNode} node - member expression node
+       */
+      MemberExpression: function (node) {
+        if (node.object.name !== propTypesVarName) {
+          return
+        }
+
+        var propertyName = node.property.name
+
+        if (propertyName in propertyValidators) {
+          propertyValidators[propertyName](context, node)
+          return
+        }
+
+        // If invalid/unknown property
+        context.report({
+          message: propertyName + ' is not a valid property on ' + propTypesVarName,
+          node: node.property
+        })
+      },
+      /**
+       * Get PropTypes variable name from import statement
+       * @example `import {PropTypes} from 'ember-prop-types'` would yield "PropTypes"
+       * @example `import {PropTypes as PT} from 'ember-prop-types'` would yield "PT"
+       * @param {ESLintNode} node - import declaration node
+       */
+      ImportDeclaration: function (node) {
+        if (node.source.value === 'ember-prop-types') {
+          node.specifiers
+            .forEach(function (specifier) {
+              if (
+                specifier.type === 'ImportSpecifier' &&
+                specifier.imported.name === 'PropTypes'
+              ) {
+                propTypesVarName = specifier.local.name
+              }
+            })
+        }
+      }
+    }
+  },
+  meta: {
+    deprecated: false,
+    docs: {
+      category: 'Possible Errors',
+      description: 'Prevent invalid usage of PropTypes from ember-prop-types',
+      recommended: true
+    }
+  }
+}

--- a/tests/prop-types.js
+++ b/tests/prop-types.js
@@ -1,0 +1,764 @@
+var RuleTester = require('eslint').RuleTester
+var rule = require('../rules/prop-types')
+
+var ruleTester = new RuleTester()
+
+ruleTester.run('prop-types', rule, {
+  invalid: [
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.doesNotExist\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 20,
+          line: 4,
+          message: 'doesNotExist is not a valid property on PropTypes',
+          type: 'Identifier'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes as PT} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PT.doesNotExist\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 13,
+          line: 4,
+          message: 'doesNotExist is not a valid property on PT',
+          type: 'Identifier'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.any()\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 20,
+          line: 4,
+          message: 'any should not be a call expression',
+          type: 'Identifier'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.array()\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 20,
+          line: 4,
+          message: 'array should not be a call expression',
+          type: 'Identifier'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.bool()\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 20,
+          line: 4,
+          message: 'bool should not be a call expression',
+          type: 'Identifier'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.element()\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 20,
+          line: 4,
+          message: 'element should not be a call expression',
+          type: 'Identifier'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.EmberObject()\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 20,
+          line: 4,
+          message: 'EmberObject should not be a call expression',
+          type: 'Identifier'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.func()\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 20,
+          line: 4,
+          message: 'func should not be a call expression',
+          type: 'Identifier'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.null()\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 20,
+          line: 4,
+          message: 'null should not be a call expression',
+          type: 'Identifier'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.number()\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 20,
+          line: 4,
+          message: 'number should not be a call expression',
+          type: 'Identifier'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.object()\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 20,
+          line: 4,
+          message: 'object should not be a call expression',
+          type: 'Identifier'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.string()\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 20,
+          line: 4,
+          message: 'string should not be a call expression',
+          type: 'Identifier'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.symbol()\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 20,
+          line: 4,
+          message: 'symbol should not be a call expression',
+          type: 'Identifier'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.arrayOf\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 20,
+          line: 4,
+          message: 'arrayOf should be a call expression',
+          type: 'Identifier'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.instanceOf\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 20,
+          line: 4,
+          message: 'instanceOf should be a call expression',
+          type: 'Identifier'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.oneOf\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 20,
+          line: 4,
+          message: 'oneOf should be a call expression',
+          type: 'Identifier'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.oneOfType\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 20,
+          line: 4,
+          message: 'oneOfType should be a call expression',
+          type: 'Identifier'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.shape\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 20,
+          line: 4,
+          message: 'shape should be a call expression',
+          type: 'Identifier'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.arrayOf("a", "b")\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 10,
+          line: 4,
+          message: 'arrayOf call expression should only have one argument',
+          type: 'CallExpression'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.instanceOf("a", "b")\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 10,
+          line: 4,
+          message: 'instanceOf call expression should only have one argument',
+          type: 'CallExpression'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.oneOf([], "b")\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 10,
+          line: 4,
+          message: 'oneOf call expression should only have one argument',
+          type: 'CallExpression'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.oneOfType([], "b")\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 10,
+          line: 4,
+          message: 'oneOfType call expression should only have one argument',
+          type: 'CallExpression'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.shape({}, "b")\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 10,
+          line: 4,
+          message: 'shape call expression should only have one argument',
+          type: 'CallExpression'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.oneOf("a")\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 26,
+          line: 4,
+          message: 'argument should be an array expression'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.oneOf(1)\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 26,
+          line: 4,
+          message: 'argument should be an array expression'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.oneOf(true)\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 26,
+          line: 4,
+          message: 'argument should be an array expression'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.oneOf({})\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 26,
+          line: 4,
+          message: 'argument should be an array expression'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.oneOfType("a")\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 30,
+          line: 4,
+          message: 'argument should be an array expression'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.oneOfType(1)\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 30,
+          line: 4,
+          message: 'argument should be an array expression'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.oneOfType(true)\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 30,
+          line: 4,
+          message: 'argument should be an array expression'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.oneOfType({})\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 30,
+          line: 4,
+          message: 'argument should be an array expression'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.shape("a")\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 26,
+          line: 4,
+          message: 'argument should be an object expression'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.shape(1)\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 26,
+          line: 4,
+          message: 'argument should be an object expression'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.shape(true)\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 26,
+          line: 4,
+          message: 'argument should be an object expression'
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.shape([])\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 26,
+          line: 4,
+          message: 'argument should be an object expression'
+        }
+      ],
+      parser: 'babel-eslint'
+    }
+  ],
+  valid: [
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Ember.Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.any\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Ember.Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.array\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Ember.Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.arrayOf(PropTypes.bool)\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Ember.Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.bool\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Ember.Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.element\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Ember.Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.EmberObject\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Ember.Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.func\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Ember.Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.instanceOf(HTMLElement)\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Ember.Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.null\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Ember.Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.number\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Ember.Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.object\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Ember.Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.oneOf(["bar", "baz"])\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Ember.Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.oneOfType([\n' +
+            '      PropTypes.null,\n' +
+            '      PropTypes.string\n' +
+            '    ])\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Ember.Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.shape({\n' +
+            '      bar: PropTypes.bool,\n' +
+            '      baz: PropTypes.number\n' +
+            '    })\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Ember.Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.string\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Ember.Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.symbol\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes as PT} from "ember-prop-types"\n' +
+            'export default Ember.Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PT.symbol\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Component} = Ember\n' +
+            'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.symbol\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    }
+  ]
+})


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Resolves #20

# CHANGELOG

* **Added** `prop-types` rule to validate `PropTypes` from `ember-prop-types`.
