### PR TITLE
Fix logger rule when never option passed in

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,37 @@
 module.exports = {
   extends: ['standard'],
   rules: {
-    complexity: [2, 5]
+    camelcase: 2,
+    complexity: [2, 5],
+    'max-len': [2, 120, 4, {
+      ignoreComments: true,
+      ignoreUrls: true
+    }],
+    'require-jsdoc': 2,
+    'valid-jsdoc': [
+      2,
+      {
+        prefer: {
+          const: 'constant',
+          'constructor': 'class',
+          arg: 'param',
+          argument: 'param',
+          defaultvalue: 'default',
+          desc: 'description',
+          emits: 'fires',
+          exception: 'throws',
+          extends: 'augments',
+          fileoverview: 'file',
+          func: 'function',
+          host: 'external',
+          method: 'function',
+          overview: 'file',
+          return: 'returns',
+          var: 'member',
+          virtual: 'abstract'
+        },
+        requireReturn: false
+      }
+    ]
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
-  config: ['standard']
+  extends: ['standard'],
+  rules: {
+    complexity: [2, 5]
+  }
 }

--- a/index.js
+++ b/index.js
@@ -2,10 +2,10 @@ module.exports = {
   configs: {
     'ember-standard': {
       rules: {
-        'ember-standard/computed-property-readonly': [2, "always"],
-        'ember-standard/destructure': [2, "always"],
-        'ember-standard/import': [2, "always"],
-        'ember-standard/logger': [2, "always"],
+        'ember-standard/computed-property-readonly': [2, 'always'],
+        'ember-standard/destructure': [2, 'always'],
+        'ember-standard/import': [2, 'always'],
+        'ember-standard/logger': [2, 'always'],
         'ember-standard/no-set-in-computed-property': 2,
         'ember-standard/no-settimeout': 2,
         'ember-standard/prop-types': 2,

--- a/rules/destructure.js
+++ b/rules/destructure.js
@@ -84,9 +84,8 @@ module.exports = {
 
         // Add destructured properties to existing Ember destructure variable declarator
         if (emberDestructureVariableDeclarator) {
-          var lastProperty = emberDestructureVariableDeclarator.id.properties[
-            emberDestructureVariableDeclarator.id.properties.length - 1
-          ]
+          var lastProperty = emberDestructureVariableDeclarator.id
+            .properties[emberDestructureVariableDeclarator.id.properties.length - 1]
 
           context.report({
             fix: function (fixer) {

--- a/rules/destructure.js
+++ b/rules/destructure.js
@@ -3,6 +3,11 @@ var reservedNames = [
   'String'
 ]
 
+/**
+ * Captialize string by uppercasing first character
+ * @param {String} string - string to captialize
+ * @returns {String} capitalized string
+ */
 function capitalize (string) {
   return string[0].toUpperCase() + string.split('').slice(1).join('')
 }

--- a/rules/logger.js
+++ b/rules/logger.js
@@ -7,6 +7,68 @@ var VALID_LOGGER_METHODS = [
   'warn'
 ]
 
+function isConsolePropertyCall (node) {
+  return (
+    node.callee.object &&
+    node.callee.object.name === 'console' &&
+    VALID_LOGGER_METHODS.indexOf(node.callee.property.name) !== -1
+  )
+}
+
+function isDestructuredLoggerPropertyCall (node, loggerVarName) {
+  return (
+    node.callee.object &&
+    node.callee.object.name === loggerVarName &&
+    VALID_LOGGER_METHODS.indexOf(node.callee.property.name) !== -1
+  )
+}
+
+function isStructuredLoggerPropertyCall (node, emberVarName) {
+  return (
+    node.callee.object &&
+    node.callee.object.object &&
+    node.callee.object.object.name === emberVarName &&
+    node.callee.object.property.name === 'Logger' &&
+    VALID_LOGGER_METHODS.indexOf(node.callee.property.name) !== -1
+  )
+
+  // TODO: check if parent object is emberVarName
+}
+
+function reportUseConsoleInsteadOfDestructuredLogger (context, node, loggerVarName) {
+  context.report({
+    fix: function (fixer) {
+      return fixer.replaceText(node.callee.object, 'console')
+    },
+    message: 'Use console instead of ' + loggerVarName,
+    node: node.callee.object
+  })
+}
+
+function reportUseConsoleInsteadOfStructuredLogger (context, node, emberVarName, loggerVarName) {
+  var current = loggerVarName || emberVarName + '.Logger'
+
+  context.report({
+    fix: function (fixer) {
+      return fixer.replaceText(node.callee.object, 'console')
+    },
+    message: 'Use console instead of ' + current,
+    node: node.callee.object
+  })
+}
+
+function reportUseLoggerInsteadOfConsole (context, node, emberVarName, loggerVarName) {
+  var replacement = loggerVarName || emberVarName + '.Logger'
+
+  context.report({
+    fix: function (fixer) {
+      return fixer.replaceText(node.callee.object, replacement)
+    },
+    message: 'Use ' + replacement + ' instead of console',
+    node: node.callee.object
+  })
+}
+
 module.exports = {
   create: function (context) {
     var emberVarName = null
@@ -21,22 +83,21 @@ module.exports = {
        * @param {ESLintNode} node - call expression node
        */
       CallExpression: function (node) {
-        if (
-          emberVarName &&
-          node.callee.object &&
-          node.callee.object.name === 'console' &&
-          VALID_LOGGER_METHODS.indexOf(node.callee.property.name) !== -1
-        ) {
-          var propertyName = node.callee.property.name
-          var replacement = loggerVarName || emberVarName + '.Logger'
+        if (!isNever) {
+          if (emberVarName && isConsolePropertyCall(node)) {
+            reportUseLoggerInsteadOfConsole(context, node, emberVarName, loggerVarName)
+          }
 
-          context.report({
-            fix: function (fixer) {
-              return fixer.replaceText(node.callee.object, replacement)
-            },
-            message: 'Use ' + replacement + ' instead of console',
-            node: node.callee.object
-          })
+          return
+        }
+
+        if (isStructuredLoggerPropertyCall(node, emberVarName)) {
+          reportUseConsoleInsteadOfStructuredLogger(context, node, emberVarName, loggerVarName)
+          return
+        }
+
+        if (isDestructuredLoggerPropertyCall(node, loggerVarName)) {
+          reportUseConsoleInsteadOfDestructuredLogger(context, node, loggerVarName)
         }
       },
 

--- a/rules/logger.js
+++ b/rules/logger.js
@@ -7,6 +7,12 @@ var VALID_LOGGER_METHODS = [
   'warn'
 ]
 
+/**
+ * Determine if call expression is a console call that can be converted to a
+ * Ember.Logger call
+ * @param {ESLintNode} node - call expression node
+ * @returns {Boolean} whether or not console call
+ */
 function isConsolePropertyCall (node) {
   return (
     node.callee.object &&
@@ -15,6 +21,13 @@ function isConsolePropertyCall (node) {
   )
 }
 
+/**
+ * Determine if call expression is a destructured Ember.Logger call that can be
+ * converted to a console call
+ * @param {ESLintNode} node - call expression node
+ * @param {String} loggerVarName - variable name for Ember.Logger
+ * @returns {Boolean} whether or not destructured Ember.Logger call
+ */
 function isDestructuredLoggerPropertyCall (node, loggerVarName) {
   return (
     node.callee.object &&
@@ -23,6 +36,13 @@ function isDestructuredLoggerPropertyCall (node, loggerVarName) {
   )
 }
 
+/**
+ * Determine if call expression is a structured Ember.Logger call that can be
+ * converted to a console call
+ * @param {ESLintNode} node - call expression node
+ * @param {String} emberVarName - variable name for Ember
+ * @returns {Boolean} whether or not structured Ember.Logger call
+ */
 function isStructuredLoggerPropertyCall (node, emberVarName) {
   return (
     node.callee.object &&
@@ -35,6 +55,12 @@ function isStructuredLoggerPropertyCall (node, emberVarName) {
   // TODO: check if parent object is emberVarName
 }
 
+/**
+ * Report that console should be used instead of destructured Ember.Logger
+ * @param {ESLintContext} context - test context
+ * @param {ESLintNode} node - call expression node
+ * @param {String} loggerVarName - variable name for Ember.Logger
+ */
 function reportUseConsoleInsteadOfDestructuredLogger (context, node, loggerVarName) {
   context.report({
     fix: function (fixer) {
@@ -45,6 +71,13 @@ function reportUseConsoleInsteadOfDestructuredLogger (context, node, loggerVarNa
   })
 }
 
+/**
+ * Report that console should be used instead of structured Ember.Logger
+ * @param {ESLintContext} context - test context
+ * @param {ESLintNode} node - call expression node
+ * @param {String} emberVarName - variable name for Ember
+ * @param {String} loggerVarName - variable name for Ember.Logger
+ */
 function reportUseConsoleInsteadOfStructuredLogger (context, node, emberVarName, loggerVarName) {
   var current = loggerVarName || emberVarName + '.Logger'
 
@@ -57,6 +90,13 @@ function reportUseConsoleInsteadOfStructuredLogger (context, node, emberVarName,
   })
 }
 
+/**
+ * Report that Ember.Logger should be used instead of console
+ * @param {ESLintContext} context - test context
+ * @param {ESLintNode} node - call expression node
+ * @param {String} emberVarName - variable name for Ember
+ * @param {String} loggerVarName - variable name for Ember.Logger
+ */
 function reportUseLoggerInsteadOfConsole (context, node, emberVarName, loggerVarName) {
   var replacement = loggerVarName || emberVarName + '.Logger'
 

--- a/rules/no-set-in-computed-property.js
+++ b/rules/no-set-in-computed-property.js
@@ -1,7 +1,7 @@
 /**
  * Get start location of computed property (or null if not a CP)
  * @param {ESLintNode} node - call expression node
- * @param {String} setVarName - destructured variable name for Ember.computed
+ * @param {String} computedVarName - destructured variable name for Ember.computed
  * @returns {Number} start location of computed property (or null if not a CP)
  */
 function getComputedPropertyStart (node, computedVarName) {

--- a/rules/prop-types.js
+++ b/rules/prop-types.js
@@ -1,3 +1,8 @@
+/**
+ * Validate basic property
+ * @param {ESLintContext} context - test context
+ * @param {ESLintNode} node - member expression node
+ */
 function basicPropertyValidator (context, node) {
   if (
     node.parent.type === 'CallExpression' &&
@@ -10,6 +15,12 @@ function basicPropertyValidator (context, node) {
   }
 }
 
+/**
+ * Validate function call property that expects one argument
+ * @param {ESLintContext} context - test context
+ * @param {ESLintNode} node - member expression node
+ * @returns {Boolean} whether or not an error was found
+ */
 function functionWithOneArgValidator (context, node) {
   if (
     node.parent.type !== 'CallExpression' ||
@@ -35,6 +46,11 @@ function functionWithOneArgValidator (context, node) {
   return false
 }
 
+/**
+ * Validate function call property that expects one array argument
+ * @param {ESLintContext} context - test context
+ * @param {ESLintNode} node - member expression node
+ */
 function functionWithArrayArgValidator (context, node) {
   if (functionWithOneArgValidator(context, node)) {
     return
@@ -48,6 +64,11 @@ function functionWithArrayArgValidator (context, node) {
   }
 }
 
+/**
+ * Validate function call property that expects one object argument
+ * @param {ESLintContext} context - test context
+ * @param {ESLintNode} node - member expression node
+ */
 function functionWithObjectArgValidator (context, node) {
   if (functionWithOneArgValidator(context, node)) {
     return
@@ -107,6 +128,7 @@ module.exports = {
           node: node.property
         })
       },
+
       /**
        * Get PropTypes variable name from import statement
        * @example `import {PropTypes} from 'ember-prop-types'` would yield "PropTypes"

--- a/rules/single-destructure.js
+++ b/rules/single-destructure.js
@@ -1,3 +1,9 @@
+/**
+ * Sort properties by name
+ * @param {ESLintNode} a - first property
+ * @param {ESLintNode} b - second property
+ * @returns {Number} number indicating sort order
+ */
 function propertySorter (a, b) {
   return a.key.name > b.key.name
 }

--- a/tests/computed-property-readonly.js
+++ b/tests/computed-property-readonly.js
@@ -506,7 +506,7 @@ ruleTester.run('computed-property-readonly', rule, {
               '  }\n' +
               '})',
       parser: 'babel-eslint'
-    },
+    }
   ],
   valid: [
     {

--- a/tests/destructure.js
+++ b/tests/destructure.js
@@ -1,6 +1,11 @@
 var RuleTester = require('eslint').RuleTester
 var rule = require('../rules/destructure')
 
+/**
+ * Create valid test with always option
+ * @param {String} code - code for test
+ * @returns {ESLintTestObject} test
+ */
 function validAlwaysTest (code) {
   return {
     code: code,
@@ -9,6 +14,11 @@ function validAlwaysTest (code) {
   }
 }
 
+/**
+ * Create valid test with never option
+ * @param {String} code - code for test
+ * @returns {ESLintTestObject} test
+ */
 function validNeverTest (code) {
   return {
     code: code,

--- a/tests/logger.js
+++ b/tests/logger.js
@@ -9,6 +9,14 @@ function validAlwaysTest (code) {
   }
 }
 
+function validNeverTest (code) {
+  return {
+    code: code,
+    options: ['never'],
+    parser: 'babel-eslint'
+  }
+}
+
 var ruleTester = new RuleTester()
 
 ruleTester.run('logger', rule, {
@@ -320,6 +328,60 @@ ruleTester.run('logger', rule, {
       options: ['always'],
       output: 'import Foo from "ember"; const {Logger: Logga} = Foo; Logga.warn("Test")',
       parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'Ember.Logger.warn("Test")',
+      errors: [
+        {
+          column: 1,
+          line: 2,
+          message: 'Use console instead of Ember.Logger',
+          type: 'MemberExpression'
+        }
+      ],
+      options: ['never'],
+      output: 'import Ember from "ember"\n' +
+              'console.warn("Test")',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Logger} = Ember\n' +
+            'Logger.warn("Test")',
+      errors: [
+        {
+          column: 1,
+          line: 3,
+          message: 'Use console instead of Logger',
+          type: 'Identifier'
+        }
+      ],
+      options: ['never'],
+      output: 'import Ember from "ember"\n' +
+              'const {Logger} = Ember\n' +
+              'console.warn("Test")',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Component, Logger} = Ember\n' +
+            'Logger.warn("Test")\n' +
+            'export default Component.extend({})',
+      errors: [
+        {
+          column: 1,
+          line: 3,
+          message: 'Use console instead of Logger',
+          type: 'Identifier'
+        }
+      ],
+      options: ['never'],
+      output: 'import Ember from "ember"\n' +
+              'const {Component, Logger} = Ember\n' +
+              'console.warn("Test")\n' +
+              'export default Component.extend({})',
+      parser: 'babel-eslint'
     }
   ],
   valid: [
@@ -334,5 +396,10 @@ ruleTester.run('logger', rule, {
     validAlwaysTest('import Ember from "ember"; const {Logger} = Ember; Logger.info("Test")'),
     validAlwaysTest('import Foo from "ember"; const {Logger} = Foo; Logger.info("Test")'),
     validAlwaysTest('import Ember from "ember"; console.clear()'),
+    validNeverTest('console.info("Test")'),
+    validNeverTest('import Ember from "ember"; console.info("Test")'),
+    validNeverTest('import Ember from "ember"; const {Logger} = Ember; console.info("Test")'),
+    validNeverTest('import Foo from "ember"; console.info("Test")'),
+    validNeverTest('import Foo from "ember"; const {Logger} = Foo; console.info("Test")')
   ]
 })

--- a/tests/logger.js
+++ b/tests/logger.js
@@ -1,6 +1,11 @@
 var RuleTester = require('eslint').RuleTester
 var rule = require('../rules/logger')
 
+/**
+ * Create valid test with always option
+ * @param {String} code - code for test
+ * @returns {ESLintTestObject} test
+ */
 function validAlwaysTest (code) {
   return {
     code: code,
@@ -9,6 +14,11 @@ function validAlwaysTest (code) {
   }
 }
 
+/**
+ * Create valid test with never option
+ * @param {String} code - code for test
+ * @returns {ESLintTestObject} test
+ */
 function validNeverTest (code) {
   return {
     code: code,

--- a/tests/no-set-in-computed-property.js
+++ b/tests/no-set-in-computed-property.js
@@ -129,7 +129,7 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '  @computed("bar")\n' +
       '  foo (bar) {\n' +
       '    set(this, "baz", "spam")\n' +
-      '    return `${bar}-test`\n' +
+      '    return bar + "-test"\n' +
       '  }\n' +
       '})',
       7
@@ -143,7 +143,7 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '  @computed("bar")\n' +
       '  foo (bar) {\n' +
       '    set(this, "baz", "spam")\n' +
-      '    return `${bar}-test`\n' +
+      '    return bar + "-test"\n' +
       '  }\n' +
       '})',
       8
@@ -156,7 +156,7 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '  @computed("bar")\n' +
       '  foo (bar) {\n' +
       '    this.set("baz", "spam")\n' +
-      '    return `${bar}-test`\n' +
+      '    return bar + "-test"\n' +
       '  }\n' +
       '})',
       7
@@ -170,7 +170,7 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '  @computed("bar")\n' +
       '  foo (bar) {\n' +
       '    this.set("baz", "spam")\n' +
-      '    return `${bar}-test`\n' +
+      '    return bar + "-test"\n' +
       '  }\n' +
       '})',
       8

--- a/tests/no-set-in-computed-property.js
+++ b/tests/no-set-in-computed-property.js
@@ -1,6 +1,12 @@
 var RuleTester = require('eslint').RuleTester
 var rule = require('../rules/no-set-in-computed-property')
 
+/**
+ * Create invalid test with always option
+ * @param {String} code - code for test
+ * @param {Number} line - line error is on
+ * @returns {ESLintTestObject} test
+ */
 function invalidAlwaysTest (code, line) {
   return {
     code: code,
@@ -16,6 +22,11 @@ function invalidAlwaysTest (code, line) {
   }
 }
 
+/**
+ * Create valid test with always option
+ * @param {String} code - code for test
+ * @returns {ESLintTestObject} test
+ */
 function validAlwaysTest (code) {
   return {
     code: code,

--- a/tests/no-settimeout.js
+++ b/tests/no-settimeout.js
@@ -196,7 +196,7 @@ ruleTester.run('no-settimeout', rule, {
               'runna.later(this, () => {}, 100)\n' +
               'runna.later(this, () => {console.info("test")}, 321)',
       parser: 'babel-eslint'
-    },
+    }
   ],
   valid: [
     {

--- a/tests/single-destructure.js
+++ b/tests/single-destructure.js
@@ -84,7 +84,6 @@ ruleTester.run('single-destructure', rule, {
       output: 'import Foo from "ember";\nconst {Component, Logger} = Foo;\n',
       parser: 'babel-eslint'
     },
-    ,
     {
       code: 'import Foo from "ember";\nconst {Component} = Foo;\nconst {Logger} = Foo;\nconst {A} = Foo',
       errors: [

--- a/tests/single-destructure.js
+++ b/tests/single-destructure.js
@@ -1,6 +1,11 @@
 var RuleTester = require('eslint').RuleTester
 var rule = require('../rules/single-destructure')
 
+/**
+ * Create valid test
+ * @param {String} code - code for test
+ * @returns {ESLintTestObject} test
+ */
 function validTest (code) {
   return {
     code: code,
@@ -145,7 +150,8 @@ ruleTester.run('single-destructure', rule, {
       parser: 'babel-eslint'
     },
     {
-      code: 'import Ember from "ember"; const {Logger: Log1} = Ember; const {Logger: Log2} = Ember; Log1.info("Test"); Log2.info("Test")',
+      code: 'import Ember from "ember"; const {Logger: Log1} = Ember; const {Logger: Log2} = Ember;' +
+            ' Log1.info("Test"); Log2.info("Test")',
       errors: [
         {
           column: 64,


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** stricter ESLint rules to this project to force use of JSDoc comments everywhere, ensure JSDoc comments are valid, prevent methods with a complexity over 5, and prevent lines longer than 120 characters. This included cleaning up the codebase to comply with these stricter rules.
* **Fixed** `logger` rule to work with `never` option.
