### PR TITLE
Fix no-set-in-computed-property rule to work with decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # eslint-plugin-ember-standard
 
+ESlint rules for Ember projects.
+
 ###### Dependencies
 
 ![Node][node-img]

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "bugs": {
     "url": "https://github.com/ciena-blueplanet/eslint-plugin-ember-standard/issues"
   },
+  "description": "ESLint rules for Ember projects.",
   "devDependencies": {
     "babel-eslint": "^7.1.1",
     "eslint": "^3.0.1",

--- a/tests/no-set-in-computed-property.js
+++ b/tests/no-set-in-computed-property.js
@@ -2,12 +2,12 @@ var RuleTester = require('eslint').RuleTester
 var rule = require('../rules/no-set-in-computed-property')
 
 /**
- * Create invalid test with always option
+ * Create invalid test
  * @param {String} code - code for test
  * @param {Number} line - line error is on
  * @returns {ESLintTestObject} test
  */
-function invalidAlwaysTest (code, line) {
+function invalidTest (code, line) {
   return {
     code: code,
     errors: [
@@ -23,11 +23,11 @@ function invalidAlwaysTest (code, line) {
 }
 
 /**
- * Create valid test with always option
+ * Create valid test
  * @param {String} code - code for test
  * @returns {ESLintTestObject} test
  */
-function validAlwaysTest (code) {
+function validTest (code) {
   return {
     code: code,
     options: ['always'],
@@ -39,7 +39,7 @@ var ruleTester = new RuleTester()
 
 ruleTester.run('no-set-in-computed-property', rule, {
   invalid: [
-    invalidAlwaysTest(
+    invalidTest(
       'import Ember from "ember"\n' +
       'const {Component, computed} = Ember\n' +
       'export default Component.extend({\n' +
@@ -50,7 +50,7 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '})',
       5
     ),
-    invalidAlwaysTest(
+    invalidTest(
       'import Ember from "ember"\n' +
       'export default Ember.Component.extend({\n' +
       '  foo: Ember.computed("bar", function () {\n' +
@@ -60,7 +60,7 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '})',
       4
     ),
-    invalidAlwaysTest(
+    invalidTest(
       'export default Ember.Component.extend({\n' +
       '  foo: Ember.computed("bar", function () {\n' +
       '    this.set("baz", "spam")\n' +
@@ -69,7 +69,7 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '})',
       3
     ),
-    invalidAlwaysTest(
+    invalidTest(
       'import Ember from "ember"\n' +
       'const {Component, computed} = Ember\n' +
       'export default Component.extend({\n' +
@@ -80,7 +80,7 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '})',
       5
     ),
-    invalidAlwaysTest(
+    invalidTest(
       'import Ember from "ember"\n' +
       'export default Ember.Component.extend({\n' +
       '  foo: Ember.computed("bar", function () {\n' +
@@ -90,7 +90,7 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '})',
       4
     ),
-    invalidAlwaysTest(
+    invalidTest(
       'export default Ember.Component.extend({\n' +
       '  foo: Ember.computed("bar", function () {\n' +
       '    Ember.set(this, "baz", "spam")\n' +
@@ -99,7 +99,7 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '})',
       3
     ),
-    invalidAlwaysTest(
+    invalidTest(
       'import Ember from "ember"\n' +
       'const {Component, computed, set} = Ember\n' +
       'export default Component.extend({\n' +
@@ -110,7 +110,7 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '})',
       5
     ),
-    invalidAlwaysTest(
+    invalidTest(
       'import Ember from "ember"\n' +
       'const {Component, computed: computedYo, set} = Ember\n' +
       'export default Component.extend({\n' +
@@ -121,7 +121,7 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '})',
       5
     ),
-    invalidAlwaysTest(
+    invalidTest(
       'import Ember from "ember"\n' +
       'const {Component, computed, set: setta} = Ember\n' +
       'export default Component.extend({\n' +
@@ -132,7 +132,7 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '})',
       5
     ),
-    invalidAlwaysTest(
+    invalidTest(
       'import Ember from "ember"\n' +
       'const {Component, set} = Ember\n' +
       'import computed from "ember-computed-decorators"\n' +
@@ -145,7 +145,7 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '})',
       7
     ),
-    invalidAlwaysTest(
+    invalidTest(
       'import Ember from "ember"\n' +
       'const {Component, set} = Ember\n' +
       'import computed, {readOnly} from "ember-computed-decorators"\n' +
@@ -159,7 +159,7 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '})',
       8
     ),
-    invalidAlwaysTest(
+    invalidTest(
       'import Ember from "ember"\n' +
       'const {Component} = Ember\n' +
       'import computed from "ember-computed-decorators"\n' +
@@ -172,7 +172,7 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '})',
       7
     ),
-    invalidAlwaysTest(
+    invalidTest(
       'import Ember from "ember"\n' +
       'const {Component} = Ember\n' +
       'import computed, {readOnly} from "ember-computed-decorators"\n' +
@@ -186,7 +186,7 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '})',
       8
     ),
-    invalidAlwaysTest(
+    invalidTest(
       'const foo = "bar"\n' +
       'export default Ember.Component.extend({\n' +
       '  foo: Ember.computed("bar", function () {\n' +
@@ -195,10 +195,48 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '  })\n' +
       '})',
       4
+    ),
+    invalidTest(
+      'const foo = "bar"\n' +
+      'export default Ember.Component.extend({\n' +
+      '  foo: Ember.computed("bar", function () {\n' +
+      '    this.set("baz", "spam")\n' +
+      '    return "test"\n' +
+      '  }),\n' +
+      '  bar () {\n' +
+      '    this.set("baz", "tofu")\n' +
+      '  }\n' +
+      '})',
+      4
+    ),
+    invalidTest(
+      'import computed from "ember-computed-decorators"\n' +
+      'export default Ember.Component.extend({\n' +
+      '  @computed("bar")\n' +
+      '  foo (bar) {\n' +
+      '    this.set("baz", "spam")\n' +
+      '    return "test"\n' +
+      '  },\n' +
+      '  bar () {\n' +
+      '    this.set("baz", "tofu")\n' +
+      '  }\n' +
+      '})',
+      5
+    ),
+    invalidTest(
+      'import pooted from "ember-computed-decorators"\n' +
+      'export default Ember.Component.extend({\n' +
+      '  @pooted("bar")\n' +
+      '  foo (bar) {\n' +
+      '    this.set("baz", "spam")\n' +
+      '    return "test"\n' +
+      '  }\n' +
+      '})',
+      5
     )
   ],
   valid: [
-    validAlwaysTest(
+    validTest(
       'import Ember from "ember"\n' +
       'const {Component, computed} = Ember\n' +
       'export default Component.extend({\n' +
@@ -207,7 +245,7 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '  })\n' +
       '})'
     ),
-    validAlwaysTest(
+    validTest(
       'import Ember from "ember"\n' +
       'export default Ember.Component.extend({\n' +
       '  foo: Ember.computed("bar", function () {\n' +
@@ -215,14 +253,14 @@ ruleTester.run('no-set-in-computed-property', rule, {
       '  })\n' +
       '})'
     ),
-    validAlwaysTest(
+    validTest(
       'export default Ember.Component.extend({\n' +
       '  foo: Ember.computed("bar", function () {\n' +
       '    return "test"\n' +
       '  })\n' +
       '})'
     ),
-    validAlwaysTest(
+    validTest(
       'export default Ember.Component.extend({\n' +
       '  foo: Ember.computed("bar", function () {\n' +
       '    alpha.set("test", "bar")\n' +


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** `no-set-in-computed-property` rule to work with [ember-computed-decorators](https://github.com/rwjblue/ember-computed-decorators).
