### PR TITLE
Fix computed-property-readonly rule to import readOnly

### DIFF
--- a/rules/computed-property-readonly.js
+++ b/rules/computed-property-readonly.js
@@ -17,14 +17,17 @@ function reportMissingReadOnly (context, node) {
  * Report that computed property is not currently readOnly
  * @param {ESLintContext} context - context
  * @param {ESLintNode} node - node representing computed decorator
+ * @param {String} readOnlyVarName - variable name for readOnly decorator
  */
-function reportMissingReadOnlyDecorator (context, node) {
+function reportMissingReadOnlyDecorator (context, node, readOnlyVarName) {
+  readOnlyVarName = readOnlyVarName || 'readOnly'
+
   context.report({
     fix: function (fixer) {
       var computedDecoratorLine = context.getSourceCode().lines[node.parent.loc.start.line - 1]
       var leadingWhiteSpace = computedDecoratorLine.replace(/^(\s*).*$/, '$1')
 
-      return fixer.insertTextBefore(node.parent, '@readOnly\n' + leadingWhiteSpace)
+      return fixer.insertTextBefore(node.parent, '@' + readOnlyVarName + '\n' + leadingWhiteSpace)
     },
     message: 'Computed property should be readOnly',
     node: node.parent.parent
@@ -56,13 +59,14 @@ function reportUnwantedReadOnly (context, node) {
  * @param {ESLintContext} context - context
  * @param {ESLintNode} node - call expression node
  * @param {Boolean} isNever - whether or not "never" option is set
+ * @param {String} computedVarName - variable name for destructured Ember.computed
  */
-function processComputed (context, node, isNever) {
-  var methodNames = ['alias', 'computed']
-  var isDirectCall = methodNames.indexOf(node.callee.name) !== -1
+function processComputed (context, node, isNever, computedVarName) {
+  var isDirectCall = computedVarName && node.callee.name === computedVarName
 
   var isNestedPropertyCall = (
-    node.callee.property && methodNames.indexOf(node.callee.property.name) !== -1
+    node.callee.property &&
+    ['alias', 'computed'].indexOf(node.callee.property.name) !== -1
   )
 
   var isReadOnly = node.parent.property && node.parent.property.name === 'readOnly'
@@ -81,13 +85,15 @@ function processComputed (context, node, isNever) {
  * @param {ESLintContext} context - context
  * @param {ESLintNode} node - call expression node
  * @param {Boolean} isNever - whether or not "never" option is set
+ * @param {String} readOnlyVarName - variable name for readOnly decorator
+ * @returns {Boolean} whether or not readOnly decorator was added
  */
-function processComputedDecorator (context, node, isNever) {
+function processComputedDecorator (context, node, isNever, readOnlyVarName) {
   var readOnlyDecorator = null
 
   node.parent.parent.decorators
     .forEach(function (decorator) {
-      if (decorator.expression.name === 'readOnly') {
+      if (decorator.expression.name === readOnlyVarName) {
         readOnlyDecorator = decorator
       }
     })
@@ -95,13 +101,21 @@ function processComputedDecorator (context, node, isNever) {
   if (readOnlyDecorator && isNever) {
     reportUnwantedReadOnly(context, readOnlyDecorator)
   } else if (!readOnlyDecorator && !isNever) {
-    reportMissingReadOnlyDecorator(context, node)
+    reportMissingReadOnlyDecorator(context, node, readOnlyVarName)
+    return true
   }
+
+  return false
 }
 
 module.exports = {
   create: function (context) {
+    var computedVarName = null
+    var emberComputedDecoratorsImportNode = null
+    var emberVarName = null
+    var importReadOnlyDecoratorVar = false
     var isNever = Boolean(context.options.length > 0 && context.options[0] === 'never')
+    var readOnlyDecoratorVarName = null
 
     return {
       /**
@@ -111,9 +125,101 @@ module.exports = {
        */
       CallExpression: function (node) {
         if (node.parent.type === 'Decorator') {
-          processComputedDecorator(context, node, isNever)
+          if (
+            processComputedDecorator(context, node, isNever, readOnlyDecoratorVarName) &&
+            !readOnlyDecoratorVarName
+          ) {
+            importReadOnlyDecoratorVar = true
+          }
         } else {
-          processComputed(context, node, isNever)
+          processComputed(context, node, isNever, computedVarName)
+        }
+      },
+
+      /**
+       * Get Ember variable name from import statement
+       * @example `import Ember from 'ember'` would yield "Ember"
+       * @example `import Foo from 'ember'` would yield "Foo"
+       * @param {ESLintNode} node - import declaration node
+       */
+      ImportDeclaration: function (node) {
+        switch (node.source.value) {
+          case 'ember':
+            emberVarName = node.specifiers[0].local.name
+            break
+
+          case 'ember-computed-decorators':
+            emberComputedDecoratorsImportNode = node
+            node.specifiers
+              .forEach(function (specifier) {
+                if (
+                  specifier.imported &&
+                  specifier.imported.name === 'readOnly'
+                ) {
+                  readOnlyDecoratorVarName = specifier.local.name
+                }
+              })
+
+            break
+        }
+      },
+
+      /**
+       * Make sure readOnly is imported from ember-computed-decorators if it is
+       * being used
+       * @param {ESLintNode} node - program node
+       */
+      'Program:exit': function (node) {
+        if (!importReadOnlyDecoratorVar) {
+          return
+        }
+
+        var specifierCount = emberComputedDecoratorsImportNode.specifiers.length
+
+        if (specifierCount > 1) {
+          context.report({
+            fix: function (fixer) {
+              return fixer.insertTextAfter(
+                emberComputedDecoratorsImportNode.specifiers[specifierCount - 1],
+                ', readOnly'
+              )
+            },
+            message: 'Needs to import readOnly',
+            node: emberComputedDecoratorsImportNode
+          })
+          return
+        }
+
+        context.report({
+          fix: function (fixer) {
+            return fixer.insertTextAfter(
+              emberComputedDecoratorsImportNode.specifiers[0],
+              ', {readOnly}'
+            )
+          },
+          message: 'Needs to import readOnly',
+          node: emberComputedDecoratorsImportNode
+        })
+      },
+
+      /**
+       * Get destructured variable names that effect this rule
+       * @example `const {computed} = Ember` would use "computed" when looking
+       * for computed properties whereas `const {computed: react} = Ember` would
+       * use "react" instead of "computed"
+       * @param {ESLintNode} node - variable declarator node
+       */
+      VariableDeclarator: function (node) {
+        if (
+          node.id.type === 'ObjectPattern' &&
+          node.init.name === emberVarName &&
+          node.id.properties.length !== 0
+        ) {
+          node.id.properties.forEach(function (property) {
+            if (property.key.name === 'computed') {
+              computedVarName = property.value.name
+            }
+          })
         }
       }
     }

--- a/tests/computed-property-readonly.js
+++ b/tests/computed-property-readonly.js
@@ -482,7 +482,8 @@ ruleTester.run('computed-property-readonly', rule, {
     },
     {
       code: 'import computed, {readOnly} from "ember-computed-decorators"\n' +
-            'export default Ember.Component.extend({\n' +
+            'const {Component} = Ember\n' +
+            'export default Component.extend({\n' +
             '  @readOnly\n' +
             '  @computed("bar")\n' +
             '  foo (bar) {\n' +
@@ -492,14 +493,81 @@ ruleTester.run('computed-property-readonly', rule, {
       errors: [
         {
           column: 3,
-          line: 3,
+          line: 4,
           message: 'Computed property should not be readOnly',
           type: 'Decorator'
         }
       ],
       options: ['never'],
       output: 'import computed, {readOnly} from "ember-computed-decorators"\n' +
+              'const {Component} = Ember\n' +
+              'export default Component.extend({\n' +
+              '  @computed("bar")\n' +
+              '  foo (bar) {\n' +
+              '    return "baz"\n' +
+              '  }\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import computed from "ember-computed-decorators"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  @computed("bar")\n' +
+            '  foo (bar) {\n' +
+            '    return "baz"\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 1,
+          line: 1,
+          message: 'Needs to import readOnly',
+          type: 'ImportDeclaration'
+        },
+        {
+          column: 3,
+          line: 4,
+          message: 'Computed property should be readOnly',
+          type: 'Property'
+        }
+      ],
+      options: ['always'],
+      output: 'import computed, {readOnly} from "ember-computed-decorators"\n' +
               'export default Ember.Component.extend({\n' +
+              '  @readOnly\n' +
+              '  @computed("bar")\n' +
+              '  foo (bar) {\n' +
+              '    return "baz"\n' +
+              '  }\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import computed, {alias} from "ember-computed-decorators"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  @computed("bar")\n' +
+            '  foo (bar) {\n' +
+            '    return "baz"\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 1,
+          line: 1,
+          message: 'Needs to import readOnly',
+          type: 'ImportDeclaration'
+        },
+        {
+          column: 3,
+          line: 4,
+          message: 'Computed property should be readOnly',
+          type: 'Property'
+        }
+      ],
+      options: ['always'],
+      output: 'import computed, {alias, readOnly} from "ember-computed-decorators"\n' +
+              'export default Ember.Component.extend({\n' +
+              '  @readOnly\n' +
               '  @computed("bar")\n' +
               '  foo (bar) {\n' +
               '    return "baz"\n' +


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** `computed-property-rule` to import `readOnly` from `ember-computed-decorators` when it adds it to the code as well as handle import/destructure variable names better.
