### PR TITLE
Fix prop-type rule to allow variable as argument

### DIFF
--- a/rules/destructure.js
+++ b/rules/destructure.js
@@ -97,7 +97,7 @@ module.exports = {
               return fixer.insertTextAfter(lastProperty, ', ' + textToInsert)
             },
             message: message,
-            node: emberDestructureVariableDeclarator
+            node: emberDestructureVariableDeclarator.parent
           })
 
         // Since there is no Ember destructure variable declarator add one after import

--- a/rules/prop-types.js
+++ b/rules/prop-types.js
@@ -56,7 +56,12 @@ function functionWithArrayArgValidator (context, node) {
     return
   }
 
-  if (node.parent.arguments[0].type !== 'ArrayExpression') {
+  var validTypes = [
+    'ArrayExpression', // Allow inline array
+    'Identifier' // Allow a variable reference
+  ]
+
+  if (validTypes.indexOf(node.parent.arguments[0].type) === -1) {
     context.report({
       message: 'argument should be an array expression',
       node: node.parent.arguments[0]
@@ -74,7 +79,12 @@ function functionWithObjectArgValidator (context, node) {
     return
   }
 
-  if (node.parent.arguments[0].type !== 'ObjectExpression') {
+  var validTypes = [
+    'Identifier', // Allow a variable reference
+    'ObjectExpression' // Allow inline array
+  ]
+
+  if (validTypes.indexOf(node.parent.arguments[0].type) === -1) {
     context.report({
       message: 'argument should be an object expression',
       node: node.parent.arguments[0]

--- a/tests/destructure.js
+++ b/tests/destructure.js
@@ -672,10 +672,10 @@ ruleTester.run('destructure', rule, {
       code: 'const {A} = Ember; const bar = Ember.MODEL_FACTORY_INJECTIONS',
       errors: [
         {
-          column: 7,
+          column: 1,
           line: 1,
           message: 'The following need destructured: MODEL_FACTORY_INJECTIONS',
-          type: 'VariableDeclarator'
+          type: 'VariableDeclaration'
         },
         {
           column: 32,

--- a/tests/prop-types.js
+++ b/tests/prop-types.js
@@ -759,6 +759,30 @@ ruleTester.run('prop-types', rule, {
             '  }\n' +
             '})',
       parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Component} = Ember\n' +
+            'const bar = ["baz", "spam"]\n' +
+            'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.oneOf(bar)\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Component} = Ember\n' +
+            'const bar = ["baz", "spam"]\n' +
+            'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+            'export default Component.extend(PropTypeMixin, {\n' +
+            '  propTypes: {\n' +
+            '    foo: PropTypes.shape(bar)\n' +
+            '  }\n' +
+            '})',
+      parser: 'babel-eslint'
     }
   ]
 })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Resolves #24

# CHANGELOG

* **Fixed** `prop-types` rule to allow argument in property methods to be a variable reference.
