### PR TITLE
Prevent duplicates when destructuring

### DIFF
--- a/tests/destructure.js
+++ b/tests/destructure.js
@@ -331,6 +331,42 @@ ruleTester.run('destructure', rule, {
               'Logger.info("Test2")',
       parser: 'babel-eslint'
     },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Logger} = Ember\n' +
+            'Ember.Logger.info("Test")',
+      errors: [
+        {
+          column: 1,
+          line: 3,
+          message: 'Ember.Logger should be destructured',
+          type: 'MemberExpression'
+        }
+      ],
+      options: ['always'],
+      output: 'import Ember from "ember"\n' +
+              'const {Logger} = Ember\n' +
+              'Logger.info("Test")',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Logger: Logga} = Ember\n' +
+            'Ember.Logger.info("Test")',
+      errors: [
+        {
+          column: 1,
+          line: 3,
+          message: 'Ember.Logger should be destructured',
+          type: 'MemberExpression'
+        }
+      ],
+      options: ['always'],
+      output: 'import Ember from "ember"\n' +
+              'const {Logger: Logga} = Ember\n' +
+              'Logga.info("Test")',
+      parser: 'babel-eslint'
+    },
 
     // Destructuring when rule is set to "never"
     {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Resolves #29

# CHANGELOG

* **Fixed** bug with fix functionality of `destructure` rule where a property could end up in the variable declarator twice.
