### PR TITLE
Use consistent ESLint API

### DIFF
--- a/rules/no-set-in-computed-property.js
+++ b/rules/no-set-in-computed-property.js
@@ -87,7 +87,10 @@ module.exports = {
           currentComputedProperty &&
           isSetCall(node, setVarName, emberVarName)
         ) {
-          context.report(node, 'Do not call this.set() or Ember.set() in a computed property')
+          context.report({
+            message: 'Do not call this.set() or Ember.set() in a computed property',
+            node: node
+          })
         }
       },
 

--- a/rules/single-destructure.js
+++ b/rules/single-destructure.js
@@ -54,6 +54,7 @@ module.exports = {
           fix: function (fixer) {
             return fixer.insertTextAfter(lastProperty, ', ' + textToInsert)
           },
+          message: '',
           node: node
         })
       },


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** `no-set-in-computed-property` rule to use consistent `context.report()` API used in other rules.
