### PR TITLE
Added EmberComponent as a valid prop type

### DIFF
--- a/rules/prop-types.js
+++ b/rules/prop-types.js
@@ -98,6 +98,7 @@ var propertyValidators = {
   arrayOf: functionWithOneArgValidator,
   bool: basicPropertyValidator,
   element: basicPropertyValidator,
+  EmberComponent: basicPropertyValidator,
   EmberObject: basicPropertyValidator,
   func: basicPropertyValidator,
   instanceOf: functionWithOneArgValidator,

--- a/tests/prop-types.js
+++ b/tests/prop-types.js
@@ -637,6 +637,15 @@ ruleTester.run('prop-types', rule, {
     },
     {
       code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
+      'export default Ember.Component.extend(PropTypeMixin, {\n' +
+      '  propTypes: {\n' +
+      '    foo: PropTypes.EmberComponent\n' +
+      '  }\n' +
+      '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import PropTypeMixin, {PropTypes} from "ember-prop-types"\n' +
             'export default Ember.Component.extend(PropTypeMixin, {\n' +
             '  propTypes: {\n' +
             '    foo: PropTypes.EmberObject\n' +


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Resolves #34

# CHANGELOG

* **Added** EmberComponent as a valid prop type
