### PR TITLE
Add support for ember-decorators with tests and documentation

### DIFF
--- a/documentation/rules/computed-property-readonly.md
+++ b/documentation/rules/computed-property-readonly.md
@@ -41,6 +41,20 @@ export default Component.extend({
 })
 ```
 
+```js
+import Ember from 'ember'
+const {Component} = Ember
+import {computed, readOnly} from 'ember-decorators/object'
+
+export default Component.extend({
+  @readOnly
+  @computed('bar')
+  foo (bar) {
+    return bar + '-baz'
+  }
+})
+```
+
 **Invalid**
 
 ```js
@@ -58,6 +72,19 @@ export default Component.extend({
 import Ember from 'ember'
 const {Component} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
+
+export default Component.extend({
+  @computed('bar')
+  foo (bar) {
+    return bar + '-baz'
+  }
+})
+```
+
+```js
+import Ember from 'ember'
+const {Component} = Ember
+import {computed, readOnly} from 'ember-decorators/object'
 
 export default Component.extend({
   @computed('bar')
@@ -107,6 +134,19 @@ export default Component.extend({
 })
 ```
 
+```js
+import Ember from 'ember'
+const {Component} = Ember
+import {computed, readOnly} from 'ember-decorators/object'
+
+export default Component.extend({
+  @computed('bar')
+  foo (bar) {
+    return bar + '-baz'
+  }
+})
+```
+
 **Invalid**
 
 ```js
@@ -133,3 +173,18 @@ export default Component.extend({
   }
 })
 ```
+
+```js
+import Ember from 'ember'
+const {Component} = Ember
+import {computed, readOnly} from 'ember-decorators/object'
+
+export default Component.extend({
+  @readOnly
+  @computed('bar')
+  foo (bar) {
+    return bar + '-baz'
+  }
+})
+```
+

--- a/rules/computed-property-readonly.js
+++ b/rules/computed-property-readonly.js
@@ -161,6 +161,20 @@ module.exports = {
               })
 
             break
+
+          case 'ember-decorators/object':
+            emberComputedDecoratorsImportNode = node
+            node.specifiers
+              .forEach(function (specifier) {
+                if (
+                  specifier.imported &&
+                  specifier.imported.name === 'readOnly'
+                ) {
+                  readOnlyDecoratorVarName = specifier.local.name
+                }
+              })
+
+            break
         }
       },
 
@@ -176,7 +190,7 @@ module.exports = {
 
         var specifierCount = emberComputedDecoratorsImportNode.specifiers.length
 
-        if (specifierCount > 1) {
+        if (specifierCount > 1 || emberComputedDecoratorsImportNode.source.value === 'ember-decorators/object') {
           context.report({
             fix: function (fixer) {
               return fixer.insertTextAfter(

--- a/tests/computed-property-readonly.js
+++ b/tests/computed-property-readonly.js
@@ -574,6 +574,95 @@ ruleTester.run('computed-property-readonly', rule, {
               '  }\n' +
               '})',
       parser: 'babel-eslint'
+    },
+    {
+      code: 'import {computed, readOnly} from "ember-decorators/object"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  @computed("bar")\n' +
+            '  foo (bar) {\n' +
+            '    return "baz"\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 3,
+          line: 4,
+          message: 'Computed property should be readOnly',
+          type: 'Property'
+        }
+      ],
+      options: ['always'],
+      output: 'import {computed, readOnly} from "ember-decorators/object"\n' +
+              'export default Ember.Component.extend({\n' +
+              '  @readOnly\n' +
+              '  @computed("bar")\n' +
+              '  foo (bar) {\n' +
+              '    return "baz"\n' +
+              '  }\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import {computed, readOnly} from "ember-decorators/object"\n' +
+            'const {Component} = Ember\n' +
+            'export default Component.extend({\n' +
+            '  @readOnly\n' +
+            '  @computed("bar")\n' +
+            '  foo (bar) {\n' +
+            '    return "baz"\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 3,
+          line: 4,
+          message: 'Computed property should not be readOnly',
+          type: 'Decorator'
+        }
+      ],
+      options: ['never'],
+      output: 'import {computed, readOnly} from "ember-decorators/object"\n' +
+              'const {Component} = Ember\n' +
+              'export default Component.extend({\n' +
+              '  @computed("bar")\n' +
+              '  foo (bar) {\n' +
+              '    return "baz"\n' +
+              '  }\n' +
+              '})',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import {computed} from "ember-decorators/object"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  @computed("bar")\n' +
+            '  foo (bar) {\n' +
+            '    return "baz"\n' +
+            '  }\n' +
+            '})',
+      errors: [
+        {
+          column: 1,
+          line: 1,
+          message: 'Needs to import readOnly',
+          type: 'ImportDeclaration'
+        },
+        {
+          column: 3,
+          line: 4,
+          message: 'Computed property should be readOnly',
+          type: 'Property'
+        }
+      ],
+      options: ['always'],
+      output: 'import {computed, readOnly} from "ember-decorators/object"\n' +
+              'export default Ember.Component.extend({\n' +
+              '  @readOnly\n' +
+              '  @computed("bar")\n' +
+              '  foo (bar) {\n' +
+              '    return "baz"\n' +
+              '  }\n' +
+              '})',
+      parser: 'babel-eslint'
     }
   ],
   valid: [
@@ -908,6 +997,29 @@ ruleTester.run('computed-property-readonly', rule, {
     },
     {
       code: 'import computed, {readOnly} from "ember-computed-decorators"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  @computed("bar")\n' +
+            '  foo (bar) {\n' +
+            '    return "baz"\n' +
+            '  }\n' +
+            '})',
+      options: ['never'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import {computed, readOnly} from "ember-decorators/object"\n' +
+            'export default Ember.Component.extend({\n' +
+            '  @readOnly\n' +
+            '  @computed("bar")\n' +
+            '  foo (bar) {\n' +
+            '    return "baz"\n' +
+            '  }\n' +
+            '})',
+      options: ['always'],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import {computed, readOnly} from "ember-decorators/object"\n' +
             'export default Ember.Component.extend({\n' +
             '  @computed("bar")\n' +
             '  foo (bar) {\n' +


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [X] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Added** support for `ember-decorators` to the `computed-readonly` rule
* **Added** tests to validate usage of the `computed-readonly` rule with `ember-decorators`
* **Added** documentation to show usage of the `computed-readonly` rule with `ember-decorators`