### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-node": "^5.2.1",
-    "eslint-plugin-promise": "^3.6.0",
+    "eslint-plugin-promise": "3.6.0",
     "eslint-plugin-standard": "^3.0.1",
     "remark-cli": "^4.0.0",
     "remark-lint": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "babel-eslint": "^8.0.3",
     "eslint-config-standard": "10.2.1",
-    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-import": "2.8.0",
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-promise": "3.6.0",
     "eslint-plugin-standard": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "babel-eslint": "^8.0.3",
     "eslint-config-standard": "10.2.1",
     "eslint-plugin-import": "2.8.0",
-    "eslint-plugin-node": "^5.2.1",
+    "eslint-plugin-node": "5.2.1",
     "eslint-plugin-promise": "3.6.0",
     "eslint-plugin-standard": "3.0.1",
     "remark-cli": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-promise": "3.6.0",
-    "eslint-plugin-standard": "^3.0.1",
+    "eslint-plugin-standard": "3.0.1",
     "remark-cli": "^4.0.0",
     "remark-lint": "^6.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "mocha": "^4.0.1"
   },
   "dependencies": {
-    "babel-eslint": "^8.0.2",
+    "babel-eslint": "^8.0.3",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-node": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "babel-eslint": "^8.0.3",
-    "eslint-config-standard": "^10.2.1",
+    "eslint-config-standard": "10.2.1",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-promise": "3.6.0",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Closes: https://github.com/ciena-blueplanet/eslint-plugin-ember-standard/issues/46

# CHANGELOG
* **Updated** babel-eslint to ^8.0.3 (verified)
* **Updated** pin eslint-plugin-promise @ 3.6.0 (verified)
* **Updated** pin eslint-plugin-standard @ 3.0.1 (verified)
* **Updated** pin eslint-config-standard @ 10.2.1 (verified)
* **Updated** pin eslint-plugin-import @ 2.8.0 (verified)
* **Updated** pin eslint-plugin-node @ 5.2.1 (verified)