### PR TITLE
Use console instead of Logger

### DIFF
--- a/rules/logger.js
+++ b/rules/logger.js
@@ -13,10 +13,10 @@ var VALID_LOGGER_METHODS = [
  * @param {ESLintNode} node - call expression node
  * @returns {Boolean} whether or not console call
  */
-function isConsolePropertyCall (node) {
+function isEmberLoggerCall (node) {
   return (
     node.callee.object &&
-    node.callee.object.name === 'console' &&
+    node.callee.object.name === 'Logger' &&
     VALID_LOGGER_METHODS.indexOf(node.callee.property.name) !== -1
   )
 }
@@ -98,13 +98,11 @@ function reportUseConsoleInsteadOfStructuredLogger (context, node, emberVarName,
  * @param {String} loggerVarName - variable name for Ember.Logger
  */
 function reportUseLoggerInsteadOfConsole (context, node, emberVarName, loggerVarName) {
-  var replacement = loggerVarName || emberVarName + '.Logger'
-
   context.report({
     fix: function (fixer) {
-      return fixer.replaceText(node.callee.object, replacement)
+      return fixer.replaceText(node.callee.object, 'console')
     },
-    message: 'Use ' + replacement + ' instead of console',
+    message: 'Use console instead of Ember.Logger',
     node: node.callee.object
   })
 }
@@ -118,14 +116,14 @@ module.exports = {
     return {
       /* eslint-disable complexity */
       /**
-       * Determine if console is being used when it shouldn't be (when Ember is
+       * Determine if Ember.Logger is being used when it shouldn't be (when Ember is
        * imported)
-       * @example `import Ember from 'ember'; console.info('Test')`
+       * @example `import Ember from 'ember'; Ember.Logger.info('Test')`
        * @param {ESLintNode} node - call expression node
        */
       CallExpression: function (node) {
         if (!isNever) {
-          if (emberVarName && isConsolePropertyCall(node)) {
+          if (emberVarName && isEmberLoggerCall(node)) {
             reportUseLoggerInsteadOfConsole(context, node, emberVarName, loggerVarName)
           }
 
@@ -177,7 +175,7 @@ module.exports = {
     deprecated: false,
     docs: {
       category: 'Best Practices',
-      description: 'Enforce usage of Ember.Logger over console',
+      description: 'Enforce usage of console over Ember.Logger',
       recommended: true
     },
     fixable: 'code',

--- a/tests/logger.js
+++ b/tests/logger.js
@@ -32,311 +32,311 @@ var ruleTester = new RuleTester()
 ruleTester.run('logger', rule, {
   invalid: [
     {
-      code: 'import Ember from "ember"; console.debug("Test")',
-      errors: [
-        {
-          column: 28,
-          line: 1,
-          message: 'Use Ember.Logger instead of console',
-          type: 'Identifier'
-        }
-      ],
-      options: ['always'],
-      output: 'import Ember from "ember"; Ember.Logger.debug("Test")',
-      parser: 'babel-eslint'
-    },
-    {
-      code: 'import Foo from "ember"; console.debug("Test")',
-      errors: [
-        {
-          column: 26,
-          line: 1,
-          message: 'Use Foo.Logger instead of console',
-          type: 'Identifier'
-        }
-      ],
-      options: ['always'],
-      output: 'import Foo from "ember"; Foo.Logger.debug("Test")',
-      parser: 'babel-eslint'
-    },
-    {
-      code: 'import Ember from "ember"; console.error("Test")',
-      errors: [
-        {
-          column: 28,
-          line: 1,
-          message: 'Use Ember.Logger instead of console',
-          type: 'Identifier'
-        }
-      ],
-      options: ['always'],
-      output: 'import Ember from "ember"; Ember.Logger.error("Test")',
-      parser: 'babel-eslint'
-    },
-    {
-      code: 'import Foo from "ember"; console.error("Test")',
-      errors: [
-        {
-          column: 26,
-          line: 1,
-          message: 'Use Foo.Logger instead of console',
-          type: 'Identifier'
-        }
-      ],
-      options: ['always'],
-      output: 'import Foo from "ember"; Foo.Logger.error("Test")',
-      parser: 'babel-eslint'
-    },
-    {
-      code: 'import Ember from "ember"; console.info("Test")',
-      errors: [
-        {
-          column: 28,
-          line: 1,
-          message: 'Use Ember.Logger instead of console',
-          type: 'Identifier'
-        }
-      ],
-      options: ['always'],
-      output: 'import Ember from "ember"; Ember.Logger.info("Test")',
-      parser: 'babel-eslint'
-    },
-    {
-      code: 'import Foo from "ember"; console.info("Test")',
-      errors: [
-        {
-          column: 26,
-          line: 1,
-          message: 'Use Foo.Logger instead of console',
-          type: 'Identifier'
-        }
-      ],
-      options: ['always'],
-      output: 'import Foo from "ember"; Foo.Logger.info("Test")',
-      parser: 'babel-eslint'
-    },
-    {
-      code: 'import Ember from "ember"; console.log("Test")',
-      errors: [
-        {
-          column: 28,
-          line: 1,
-          message: 'Use Ember.Logger instead of console',
-          type: 'Identifier'
-        }
-      ],
-      options: ['always'],
-      output: 'import Ember from "ember"; Ember.Logger.log("Test")',
-      parser: 'babel-eslint'
-    },
-    {
-      code: 'import Foo from "ember"; console.log("Test")',
-      errors: [
-        {
-          column: 26,
-          line: 1,
-          message: 'Use Foo.Logger instead of console',
-          type: 'Identifier'
-        }
-      ],
-      options: ['always'],
-      output: 'import Foo from "ember"; Foo.Logger.log("Test")',
-      parser: 'babel-eslint'
-    },
-    {
-      code: 'import Ember from "ember"; console.warn("Test")',
-      errors: [
-        {
-          column: 28,
-          line: 1,
-          message: 'Use Ember.Logger instead of console',
-          type: 'Identifier'
-        }
-      ],
-      options: ['always'],
-      output: 'import Ember from "ember"; Ember.Logger.warn("Test")',
-      parser: 'babel-eslint'
-    },
-    {
-      code: 'import Foo from "ember"; console.warn("Test")',
-      errors: [
-        {
-          column: 26,
-          line: 1,
-          message: 'Use Foo.Logger instead of console',
-          type: 'Identifier'
-        }
-      ],
-      options: ['always'],
-      output: 'import Foo from "ember"; Foo.Logger.warn("Test")',
-      parser: 'babel-eslint'
-    },
-    {
-      code: 'import Ember from "ember"; const {Logger} = Ember; console.debug("Test")',
+      code: 'import Ember from "ember"; const {Logger} = Ember; Logger.debug("Test")',
       errors: [
         {
           column: 52,
           line: 1,
-          message: 'Use Logger instead of console',
+          message: 'Use console instead of Ember.Logger',
           type: 'Identifier'
         }
       ],
       options: ['always'],
-      output: 'import Ember from "ember"; const {Logger} = Ember; Logger.debug("Test")',
+      output: 'import Ember from "ember"; const {Logger} = Ember; console.debug("Test")',
       parser: 'babel-eslint'
     },
     {
-      code: 'import Foo from "ember"; const {Logger} = Foo; console.debug("Test")',
+      code: 'import Foo from "ember"; Foo.Logger.debug("Test")',
       errors: [
         {
-          column: 48,
+          column: 26,
           line: 1,
-          message: 'Use Logger instead of console',
-          type: 'Identifier'
+          message: 'Use console instead of Ember.Logger',
+          type: 'MemberExpression'
         }
       ],
       options: ['always'],
-      output: 'import Foo from "ember"; const {Logger} = Foo; Logger.debug("Test")',
+      output: 'import Foo from "ember"; console.debug("Test")',
       parser: 'babel-eslint'
     },
     {
-      code: 'import Ember from "ember"; const {Logger} = Ember; console.error("Test")',
+      code: 'import Ember from "ember"; Ember.Logger.error("Test")',
+      errors: [
+        {
+          column: 28,
+          line: 1,
+          message: 'Use console instead of Ember.Logger',
+          type: 'MemberExpression'
+        }
+      ],
+      options: ['always'],
+      output: 'import Ember from "ember"; console.error("Test")',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"; Foo.Logger.error("Test")',
+      errors: [
+        {
+          column: 26,
+          line: 1,
+          message: 'Use console instead of Ember.Logger',
+          type: 'MemberExpression'
+        }
+      ],
+      options: ['always'],
+      output: 'import Foo from "ember"; console.error("Test")',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"; Ember.Logger.info("Test")',
+      errors: [
+        {
+          column: 28,
+          line: 1,
+          message: 'Use console instead of Ember.Logger',
+          type: 'MemberExpression'
+        }
+      ],
+      options: ['always'],
+      output: 'import Ember from "ember"; console.info("Test")',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Foo from "ember"; Foo.Logger.info("Test")',
+      errors: [
+        {
+          column: 26,
+          line: 1,
+          message: 'Use console instead of Ember.Logger',
+          type: 'MemberExpression'
+        }
+      ],
+      options: ['always'],
+      output: 'import Foo from "ember"; console.info("Test")',
+      parser: 'babel-eslint'
+    },
+    {
+      output: 'import Ember from "ember"; console.log("Test")',
+      errors: [
+        {
+          column: 28,
+          line: 1,
+          message: 'Use console instead of Ember.Logger',
+          type: 'MemberExpression'
+        }
+      ],
+      options: ['always'],
+      code: 'import Ember from "ember"; Ember.Logger.log("Test")',
+      parser: 'babel-eslint'
+    },
+    {
+      output: 'import Foo from "ember"; console.log("Test")',
+      errors: [
+        {
+          column: 26,
+          line: 1,
+          message: 'Use console instead of Ember.Logger',
+          type: 'MemberExpression'
+        }
+      ],
+      options: ['always'],
+      code: 'import Foo from "ember"; Foo.Logger.log("Test")',
+      parser: 'babel-eslint'
+    },
+    {
+      output: 'import Ember from "ember"; console.warn("Test")',
+      errors: [
+        {
+          column: 28,
+          line: 1,
+          message: 'Use console instead of Ember.Logger',
+          type: 'MemberExpression'
+        }
+      ],
+      options: ['always'],
+      code: 'import Ember from "ember"; Ember.Logger.warn("Test")',
+      parser: 'babel-eslint'
+    },
+    {
+      output: 'import Foo from "ember"; console.warn("Test")',
+      errors: [
+        {
+          column: 26,
+          line: 1,
+          message: 'Use console instead of Ember.Logger',
+          type: 'MemberExpression'
+        }
+      ],
+      options: ['always'],
+      code: 'import Foo from "ember"; Foo.Logger.warn("Test")',
+      parser: 'babel-eslint'
+    },
+    {
+      output: 'import Ember from "ember"; const {Logger} = Ember; console.debug("Test")',
       errors: [
         {
           column: 52,
           line: 1,
-          message: 'Use Logger instead of console',
+          message: 'Use console instead of Ember.Logger',
           type: 'Identifier'
         }
       ],
       options: ['always'],
-      output: 'import Ember from "ember"; const {Logger} = Ember; Logger.error("Test")',
+      code: 'import Ember from "ember"; const {Logger} = Ember; Logger.debug("Test")',
       parser: 'babel-eslint'
     },
     {
-      code: 'import Foo from "ember"; const {Logger} = Foo; console.error("Test")',
+      output: 'import Foo from "ember"; const {Logger} = Foo; console.debug("Test")',
       errors: [
         {
           column: 48,
           line: 1,
-          message: 'Use Logger instead of console',
+          message: 'Use console instead of Ember.Logger',
           type: 'Identifier'
         }
       ],
       options: ['always'],
-      output: 'import Foo from "ember"; const {Logger} = Foo; Logger.error("Test")',
+      code: 'import Foo from "ember"; const {Logger} = Foo; Logger.debug("Test")',
       parser: 'babel-eslint'
     },
     {
-      code: 'import Ember from "ember"; const {Logger} = Ember; console.info("Test")',
+      output: 'import Ember from "ember"; const {Logger} = Ember; console.error("Test")',
       errors: [
         {
           column: 52,
           line: 1,
-          message: 'Use Logger instead of console',
+          message: 'Use console instead of Ember.Logger',
           type: 'Identifier'
         }
       ],
       options: ['always'],
-      output: 'import Ember from "ember"; const {Logger} = Ember; Logger.info("Test")',
+      code: 'import Ember from "ember"; const {Logger} = Ember; Logger.error("Test")',
       parser: 'babel-eslint'
     },
     {
-      code: 'import Foo from "ember"; const {Logger} = Foo; console.info("Test")',
+      output: 'import Foo from "ember"; const {Logger} = Foo; console.error("Test")',
       errors: [
         {
           column: 48,
           line: 1,
-          message: 'Use Logger instead of console',
+          message: 'Use console instead of Ember.Logger',
           type: 'Identifier'
         }
       ],
       options: ['always'],
-      output: 'import Foo from "ember"; const {Logger} = Foo; Logger.info("Test")',
+      code: 'import Foo from "ember"; const {Logger} = Foo; Logger.error("Test")',
       parser: 'babel-eslint'
     },
     {
-      code: 'import Ember from "ember"; const {Logger} = Ember; console.log("Test")',
+      output: 'import Ember from "ember"; const {Logger} = Ember; console.info("Test")',
       errors: [
         {
           column: 52,
           line: 1,
-          message: 'Use Logger instead of console',
+          message: 'Use console instead of Ember.Logger',
           type: 'Identifier'
         }
       ],
       options: ['always'],
-      output: 'import Ember from "ember"; const {Logger} = Ember; Logger.log("Test")',
+      code: 'import Ember from "ember"; const {Logger} = Ember; Logger.info("Test")',
       parser: 'babel-eslint'
     },
     {
-      code: 'import Foo from "ember"; const {Logger} = Foo; console.log("Test")',
+      output: 'import Foo from "ember"; const {Logger} = Foo; console.info("Test")',
       errors: [
         {
           column: 48,
           line: 1,
-          message: 'Use Logger instead of console',
+          message: 'Use console instead of Ember.Logger',
           type: 'Identifier'
         }
       ],
       options: ['always'],
-      output: 'import Foo from "ember"; const {Logger} = Foo; Logger.log("Test")',
+      code: 'import Foo from "ember"; const {Logger} = Foo; Logger.info("Test")',
       parser: 'babel-eslint'
     },
     {
-      code: 'import Ember from "ember"; const {Logger} = Ember; console.warn("Test")',
+      output: 'import Ember from "ember"; const {Logger} = Ember; console.log("Test")',
       errors: [
         {
           column: 52,
           line: 1,
-          message: 'Use Logger instead of console',
+          message: 'Use console instead of Ember.Logger',
           type: 'Identifier'
         }
       ],
       options: ['always'],
-      output: 'import Ember from "ember"; const {Logger} = Ember; Logger.warn("Test")',
+      code: 'import Ember from "ember"; const {Logger} = Ember; Logger.log("Test")',
       parser: 'babel-eslint'
     },
     {
-      code: 'import Foo from "ember"; const {Logger} = Foo; console.warn("Test")',
+      output: 'import Foo from "ember"; const {Logger} = Foo; console.log("Test")',
       errors: [
         {
           column: 48,
           line: 1,
-          message: 'Use Logger instead of console',
+          message: 'Use console instead of Ember.Logger',
           type: 'Identifier'
         }
       ],
       options: ['always'],
-      output: 'import Foo from "ember"; const {Logger} = Foo; Logger.warn("Test")',
+      code: 'import Foo from "ember"; const {Logger} = Foo; Logger.log("Test")',
       parser: 'babel-eslint'
     },
     {
-      code: 'import Ember from "ember"; const {Logger: Logga} = Ember; console.warn("Test")',
+      output: 'import Ember from "ember"; const {Logger} = Ember; console.warn("Test")',
+      errors: [
+        {
+          column: 52,
+          line: 1,
+          message: 'Use console instead of Ember.Logger',
+          type: 'Identifier'
+        }
+      ],
+      options: ['always'],
+      code: 'import Ember from "ember"; const {Logger} = Ember; Logger.warn("Test")',
+      parser: 'babel-eslint'
+    },
+    {
+      output: 'import Foo from "ember"; const {Logger} = Foo; console.warn("Test")',
+      errors: [
+        {
+          column: 48,
+          line: 1,
+          message: 'Use console instead of Ember.Logger',
+          type: 'Identifier'
+        }
+      ],
+      options: ['always'],
+      code: 'import Foo from "ember"; const {Logger} = Foo; Logger.warn("Test")',
+      parser: 'babel-eslint'
+    },
+    {
+      output: 'import Ember from "ember"; const {Logger: Logga} = Ember; console.warn("Test")',
       errors: [
         {
           column: 59,
           line: 1,
-          message: 'Use Logga instead of console',
+          message: 'Use console instead of Ember.Logger',
           type: 'Identifier'
         }
       ],
       options: ['always'],
-      output: 'import Ember from "ember"; const {Logger: Logga} = Ember; Logga.warn("Test")',
+      code: 'import Ember from "ember"; const {Logger: Logga} = Ember; Logga.warn("Test")',
       parser: 'babel-eslint'
     },
     {
-      code: 'import Foo from "ember"; const {Logger: Logga} = Foo; console.warn("Test")',
+      output: 'import Foo from "ember"; const {Logger: Logga} = Foo; console.warn("Test")',
       errors: [
         {
           column: 55,
           line: 1,
-          message: 'Use Logga instead of console',
+          message: 'Use console instead of Ember.Logger',
           type: 'Identifier'
         }
       ],
       options: ['always'],
-      output: 'import Foo from "ember"; const {Logger: Logga} = Foo; Logga.warn("Test")',
+      code: 'import Foo from "ember"; const {Logger: Logga} = Foo; Logga.warn("Test")',
       parser: 'babel-eslint'
     },
     {
@@ -397,14 +397,14 @@ ruleTester.run('logger', rule, {
   valid: [
     validAlwaysTest('console.info("Test")'),
     validAlwaysTest('import Foo from "foo"; console.info("Test")'),
-    validAlwaysTest('Ember.Logger.info("Test")'),
-    validAlwaysTest('import Ember from "ember"; Ember.Logger.info("Test")'),
-    validAlwaysTest('import Ember from "ember"; const {Logger} = Ember; Logger.info("Test")'),
-    validAlwaysTest('import Ember from "ember"; const {Component, Logger} = Ember; Logger.info("Test")'),
-    validAlwaysTest('import Ember from "ember"; const x = "y"; Ember.Logger.info("Test")'),
-    validAlwaysTest('import Foo from "ember"; Foo.Logger.info("Test")'),
-    validAlwaysTest('import Ember from "ember"; const {Logger} = Ember; Logger.info("Test")'),
-    validAlwaysTest('import Foo from "ember"; const {Logger} = Foo; Logger.info("Test")'),
+    validAlwaysTest('console.info("Test")'),
+    validAlwaysTest('import Ember from "ember"; console.info("Test")'),
+    validAlwaysTest('import Ember from "ember"; const {Logger} = Ember; console.info("Test")'),
+    validAlwaysTest('import Ember from "ember"; const {Component, Logger} = Ember; console.info("Test")'),
+    validAlwaysTest('import Ember from "ember"; const x = "y"; console.info("Test")'),
+    validAlwaysTest('import Foo from "ember"; Foo.console.info("Test")'),
+    validAlwaysTest('import Ember from "ember"; const {Logger} = Ember; console.info("Test")'),
+    validAlwaysTest('import Foo from "ember"; const {Logger} = Foo; console.info("Test")'),
     validAlwaysTest('import Ember from "ember"; console.clear()'),
     validNeverTest('console.info("Test")'),
     validNeverTest('import Ember from "ember"; console.info("Test")'),


### PR DESCRIPTION
# Overview

## Summary
Use console instead of Logger. As Ember has moved to deprecate the Logger


# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [ ] #minor#
- [x] #major#

# CHANGELOG

* Use console instead of Logger. As Ember has moved to deprecate the Logger

